### PR TITLE
auto generate dependency graphs and list duplicate dependencies via CI

### DIFF
--- a/.github/workflows/generate_dependency_graphs.yml
+++ b/.github/workflows/generate_dependency_graphs.yml
@@ -1,0 +1,30 @@
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Every day at 1 AM
+    - cron:  '0 1 * * *'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Install dot
+        run: sudo apt-get install graphviz
+
+      - shell: bash
+        run: ./scripts/generate_dependency_graphs
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: png_generator # The branch the action should deploy to.
+          FOLDER: images # The folder the action should deploy.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,10 +28,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2
@@ -62,10 +58,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build
@@ -109,10 +101,6 @@ jobs:
           toolchain: stable
           override: true
 
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2
@@ -127,3 +115,19 @@ jobs:
       - name: Run tests
         shell: bash
         run: ./scripts/tests
+
+  # list all duplicate dependencies. Note that this does not error if duplicates found
+  dependencies:
+    name: List Duplicate Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Run list duplicate dependencies script
+      - shell: bash
+        run: ./scripts/duplicate_dependency_check

--- a/README.md
+++ b/README.md
@@ -14,13 +14,24 @@ An autonomous network capable of data storage/publishing/sharing as well as comp
 ## Crate Dependencies
 Crate dependencies graph:
 
-[[https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_maidsafe_dependencies.png|alt=safe_vault MaidSafe dependencies]]
+![safe_vault MaidSafe dependencies](https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_maidsafe_dependencies.png)
+
+
+### Legend
+Dependencies are coloured depending on their kind:
+* **Black:** regular dependency
+* **Purple:** build dependency
+* **Blue:** dev dependency
+* **Red:** optional dependency
+
+A dependency can be of more than one kind. In such cases, it is coloured with the following priority:
+`Regular -> Build -> Dev -> Optional`
 
 <details>
 <summary> View all safe_vault dependencies</summary>
 <p>
 
-[[https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_all_dependencies.png|alt=safe_vault all dependencies]]
+![safe_vault all dependencies](https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_all_dependencies.png)
 
 </p>
 </details>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@
 
 An autonomous network capable of data storage/publishing/sharing as well as computation, value transfer (crypto currency support) and more. See the documentation for a more detailed description of the operations involved in data storage.
 
+## Crate Dependencies
+Crate dependencies graph:
+
+[[https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_maidsafe_dependencies.png|alt=safe_vault MaidSafe dependencies]]
+
+<details>
+<summary> View all safe_vault dependencies</summary>
+<p>
+
+[[https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_all_dependencies.png|alt=safe_vault all dependencies]]
+
+</p>
+</details>
+
+Click [here](https://maidsafe.github.io/interdependency-svg-generator/) for an overview of the interdependencies of all the main MaidSafe components.
+
 ## License
 
 This SAFE Network library is licensed under the General Public License (GPL), version 3 ([LICENSE](LICENSE) https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/scripts/duplicate_dependency_check
+++ b/scripts/duplicate_dependency_check
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e -x
+
+rm -rf images
+mkdir images
+
+cargo install cargo-tree
+
+cargo tree -d

--- a/scripts/generate_dependency_graphs
+++ b/scripts/generate_dependency_graphs
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e -x
+
+rm -rf images
+mkdir images
+
+cargo install cargo-deps
+
+cargo deps --all-deps --include-orphans --filter safe_vault safe-nd parsec maidsafe_utilities routing mock-quic-p2p quic-p2p lru_time_cache fake_clock | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/safe_vault_maidsafe_dependencies.png
+cargo deps | dot -T png -o images/safe_vault_all_dependencies.png

--- a/scripts/generate_dependency_graphs
+++ b/scripts/generate_dependency_graphs
@@ -7,5 +7,5 @@ mkdir images
 
 cargo install cargo-deps
 
-cargo deps --all-deps --include-orphans --filter safe_vault safe-nd parsec maidsafe_utilities routing mock-quic-p2p quic-p2p lru_time_cache fake_clock | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/safe_vault_maidsafe_dependencies.png
+cargo deps --all-deps --include-orphans --filter safe_vault safe-nd parsec maidsafe_utilities routing mock-quic-p2p quic-p2p lru_time_cache fake_clock xor_name bls_dkg safe-network-signature-aggregator | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/safe_vault_maidsafe_dependencies.png
 cargo deps | dot -T png -o images/safe_vault_all_dependencies.png


### PR DESCRIPTION
**Clippy CI warnings causing fail** - these have been resolved in the vaults `phase 2b` branch, so I assume I don't need to resolve here as well.

**Dependency Graphs**
Adding dependency graphs will hopefully help the community and beyond visualise how our crates are interacting with each other, and how they are interacting with non-MaidSafe crates.

These graphs will update every night via CI, if any changes.

Note that with safe vault the `all dependencies` graph is very complex, not sure how much value it offers, but if it's minimised in a section then IMO there's no harm in giving readers the option to view if they want. Plus not all crates will be this complex so if this PR is accepted and we roll this out to other crates it would be good to be consistent and give the option to view all dependencies in all of them.

Tested on a fork & the CI ran & generated the graphs successfully, which were then displayed in the readme.

Preview of internal MaidSafe safe_vault dependencies graph:
![image](https://user-images.githubusercontent.com/37112040/90489033-a9b54680-e134-11ea-9f02-9c47150618fe.png)

Preview of all safe_vault dependencies graph:
![image](https://user-images.githubusercontent.com/37112040/81906563-5cb65700-95be-11ea-84df-d12319496990.png)

**List Duplicate Dependencies**
I considered listing dependencies using `cargo tree` but thought the graphs generated by `cargo deps` would be better suited for the target audience in a README. `cargo tree` however has a useful `--duplicates` option which may be useful for our developers seeing and being aware of so I've added a stage in the PR CI which will list all duplicate dependencies. This will not cause any failures if duplicates are found, the list is for information only.
`List Duplicate Dependencies` can be viewed in the CI results for this PR.
