### PR TITLE
refactor/request: introduce read/write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,7 +2249,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "safe-nd"
 version = "0.10.0"
-source = "git+https://github.com/maidsafe/safe-nd.git#7a95a24fe6868213e207391a29187efcf8ce616f"
+source = "git+https://github.com/oetyng/safe-nd.git?branch=introduce_read_write#fce4443ac0356ed92dd45af6dbf82cafb88f3cbc"
 dependencies = [
  "bincode 1.1.4",
  "crdts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rand = "~0.6.5"
 rand_chacha = "~0.1.1"
 routing_rand_core = { package = "rand_core", version = "~0.5.1" }
 routing = { git = "https://github.com/maidsafe/routing.git", branch = "igd-err" }
-safe-nd = { git = "https://github.com/maidsafe/safe-nd.git", branch = "master" }
+safe-nd = { git = "https://github.com/oetyng/safe-nd.git", branch = "introduce_read_write" }
 self_update = { version = "~0.16.0", default-features = false, features = ["rustls", "archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate"] }
 serde = { version = "1.0.97", features = ["derive"] }
 serde_json = "1.0.40"

--- a/src/client_handler/data_requests.rs
+++ b/src/client_handler/data_requests.rs
@@ -67,10 +67,9 @@ impl Sequence {
             | GetPermissions { .. }
             | GetUserPermissions { .. } => self.get(client, request, message_id),
             Delete(address) => self.initiate_deletion(client, address, message_id),
-            MutatePubPermissions { .. }
-            | MutatePrivPermissions { .. }
-            | MutateOwner { .. }
-            | Mutate(..) => self.initiate_mutation(client, request, message_id),
+            SetPubPermissions { .. } | SetPrivPermissions { .. } | SetOwner { .. } | Edit(..) => {
+                self.initiate_mutation(client, request, message_id)
+            }
         }
     }
 
@@ -107,7 +106,7 @@ impl Sequence {
             );
             return Some(Action::RespondToClient {
                 message_id,
-                response: Response::Mutation(Err(NdError::InvalidOwners)),
+                response: Response::Write(Err(NdError::InvalidOwners)),
             });
         }
 
@@ -130,7 +129,7 @@ impl Sequence {
         if address.is_pub() {
             return Some(Action::RespondToClient {
                 message_id,
-                response: Response::Mutation(Err(NdError::InvalidOperation)),
+                response: Response::Write(Err(NdError::InvalidOperation)),
             });
         }
 
@@ -237,7 +236,7 @@ impl Immutable {
                 );
                 return Some(Action::RespondToClient {
                     message_id,
-                    response: Response::Mutation(Err(NdError::InvalidOwners)),
+                    response: Response::Write(Err(NdError::InvalidOwners)),
                 });
             }
         }
@@ -261,7 +260,7 @@ impl Immutable {
         if address.kind() == IDataKind::Pub {
             return Some(Action::RespondToClient {
                 message_id,
-                response: Response::Mutation(Err(NdError::InvalidOperation)),
+                response: Response::Write(Err(NdError::InvalidOperation)),
             });
         }
         Some(Action::VoteFor(ConsensusAction::Forward {
@@ -381,7 +380,7 @@ impl Mutable {
             );
             return Some(Action::RespondToClient {
                 message_id,
-                response: Response::Mutation(Err(NdError::InvalidOwners)),
+                response: Response::Write(Err(NdError::InvalidOwners)),
             });
         }
 

--- a/src/client_handler/login_packets.rs
+++ b/src/client_handler/login_packets.rs
@@ -88,7 +88,7 @@ impl LoginPackets {
         if !login_packet.size_is_valid() {
             return Some(Action::RespondToClient {
                 message_id,
-                response: Response::Mutation(Err(NdError::ExceededSize)),
+                response: Response::Write(Err(NdError::ExceededSize)),
             });
         }
 
@@ -191,7 +191,7 @@ impl LoginPackets {
         Some(Action::RespondToClientHandlers {
             sender: *login_packet.destination(),
             rpc: Rpc::Response {
-                response: Response::Mutation(result),
+                response: Response::Write(result),
                 requester,
                 message_id,
                 refund,
@@ -306,7 +306,7 @@ impl LoginPackets {
         Some(Action::RespondToClientHandlers {
             sender: *self.id.name(),
             rpc: Rpc::Response {
-                response: Response::Mutation(result),
+                response: Response::Write(result),
                 requester,
                 message_id,
                 // Updating the login packet is free

--- a/src/client_handler/messaging.rs
+++ b/src/client_handler/messaging.rs
@@ -233,7 +233,7 @@ impl Messaging {
             | ListMDataUserPermissions(..)
             | ListMDataPermissions(..)
             | GetMDataValue(..)
-            | Mutation(..)
+            | Write(..)
             | Transaction(..) => {
                 self.respond_to_client(message_id, response);
                 None

--- a/src/data_handler/idata_handler.rs
+++ b/src/data_handler/idata_handler.rs
@@ -99,7 +99,7 @@ impl IDataHandler {
                 sender: our_name,
                 rpc: Rpc::Response {
                     requester: client_id,
-                    response: Response::Mutation(result),
+                    response: Response::Write(result),
                     message_id,
                     refund,
                     proof: None,
@@ -180,7 +180,7 @@ impl IDataHandler {
                 sender: our_name,
                 rpc: Rpc::Response {
                     requester: client_id.clone(),
-                    response: Response::Mutation(result),
+                    response: Response::Write(result),
                     message_id,
                     // Deletion is free so no refund
                     refund: None,
@@ -429,7 +429,7 @@ impl IDataHandler {
             sender: *idata_address.name(),
             rpc: Rpc::Response {
                 requester,
-                response: Response::Mutation(Ok(())),
+                response: Response::Write(Ok(())),
                 message_id,
                 refund: None,
                 proof: None,
@@ -503,7 +503,7 @@ impl IDataHandler {
             sender: *idata_address.name(),
             rpc: Rpc::Response {
                 requester,
-                response: Response::Mutation(result),
+                response: Response::Write(result),
                 message_id,
                 // Deleting data is free so, no refund
                 // This field can be put to use when deletion is incentivised

--- a/src/data_handler/idata_holder.rs
+++ b/src/data_handler/idata_holder.rs
@@ -73,7 +73,7 @@ impl IDataHolder {
         match sender {
             SrcLocation::Node(_) => Some(Action::RespondToOurDataHandlers {
                 rpc: Rpc::DuplicationComplete {
-                    response: Response::Mutation(result),
+                    response: Response::Write(result),
                     message_id,
                     proof: Some((*data.address(), accumulated_signature?)),
                 },
@@ -81,7 +81,7 @@ impl IDataHolder {
             SrcLocation::Section(_) => Some(Action::RespondToOurDataHandlers {
                 rpc: Rpc::Response {
                     requester,
-                    response: Response::Mutation(result),
+                    response: Response::Write(result),
                     message_id,
                     refund,
                     proof: Some((request, accumulated_signature?)),
@@ -166,7 +166,7 @@ impl IDataHolder {
         Some(Action::RespondToOurDataHandlers {
             rpc: Rpc::Response {
                 requester,
-                response: Response::Mutation(result),
+                response: Response::Write(result),
                 message_id,
                 refund: None,
                 proof: Some((request, accumulated_signature?)),

--- a/src/data_handler/mdata_handler.rs
+++ b/src/data_handler/mdata_handler.rs
@@ -169,7 +169,7 @@ impl MDataHandler {
             sender: *address.name(),
             rpc: Rpc::Response {
                 requester,
-                response: Response::Mutation(result),
+                response: Response::Write(result),
                 message_id,
                 refund,
                 proof: None,
@@ -197,7 +197,7 @@ impl MDataHandler {
             sender: *data.name(),
             rpc: Rpc::Response {
                 requester,
-                response: Response::Mutation(result),
+                response: Response::Write(result),
                 message_id,
                 refund,
                 proof: None,
@@ -232,7 +232,7 @@ impl MDataHandler {
             sender: *address.name(),
             rpc: Rpc::Response {
                 requester,
-                response: Response::Mutation(result),
+                response: Response::Write(result),
                 message_id,
                 // Deletion is free so no refund
                 refund: None,

--- a/src/data_handler/mod.rs
+++ b/src/data_handler/mod.rs
@@ -128,7 +128,7 @@ impl DataHandler {
             .verify(&signature, &utils::serialise(&idata_address))
         {
             match response {
-                Mutation(result) => self.handle_idata_request(|idata_handler| {
+                Write(result) => self.handle_idata_request(|idata_handler| {
                     idata_handler.update_idata_holders(
                         idata_address,
                         utils::get_source_name(sender),
@@ -381,7 +381,7 @@ impl DataHandler {
                 return None;
             }
             match response {
-                Mutation(result) => self.handle_idata_request(move |idata_handler| {
+                Write(result) => self.handle_idata_request(move |idata_handler| {
                     idata_handler.handle_mutation_resp(
                         utils::get_source_name(src),
                         requester,

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -457,7 +457,7 @@ impl<R: CryptoRng + Rng> Vault<R> {
                     }
                 }
                 Rpc::Response { response, .. } => match response {
-                    Response::Mutation(_) | Response::GetIData(_) => {
+                    Response::Write(_) | Response::GetIData(_) => {
                         self.data_handler_mut()?.handle_vault_rpc(src, rpc, None)
                     }
                     _ => unimplemented!("Should not receive: {:?}", response),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -32,9 +32,9 @@ use safe_nd::{
     MDataAddress, MDataEntries, MDataKind, MDataPermissionSet, MDataRequest, MDataSeqEntryActions,
     MDataSeqValue, MDataUnseqEntryActions, MDataValue, MDataValues, Message, MessageId,
     PubImmutableData, PublicKey, Request, Response, Result as NdResult, SData, SDataAddress,
-    SDataIndex, SDataMutationOperation, SDataOwner, SDataPrivUserPermissions,
-    SDataPubUserPermissions, SDataRequest, SDataUser, SDataUserPermissions, SeqMutableData,
-    Transaction, UnpubImmutableData, UnseqMutableData, XorName,
+    SDataIndex, SDataOwner, SDataPrivUserPermissions, SDataPubUserPermissions, SDataRequest,
+    SDataUser, SDataUserPermissions, SDataWriteOp, SeqMutableData, Transaction, UnpubImmutableData,
+    UnseqMutableData, XorName,
 };
 use safe_vault::{Result, COST_OF_PUT};
 use std::collections::{BTreeMap, BTreeSet};
@@ -1258,7 +1258,7 @@ fn app_permissions() -> Result<()> {
         common::send_request_expect_ok(
             &mut env,
             &mut app_0,
-            Request::SData(SDataRequest::Mutate(SDataMutationOperation {
+            Request::SData(SDataRequest::Mutate(SDataWriteOp {
                 address,
                 crdt_op: entries_op.crdt_op.clone(),
             })),
@@ -1268,7 +1268,7 @@ fn app_permissions() -> Result<()> {
         common::send_request_expect_err(
             &mut env,
             &mut app_1,
-            Request::SData(SDataRequest::Mutate(SDataMutationOperation {
+            Request::SData(SDataRequest::Mutate(SDataWriteOp {
                 address,
                 crdt_op: entries_op.crdt_op.clone(),
             })),
@@ -1277,7 +1277,7 @@ fn app_permissions() -> Result<()> {
         common::send_request_expect_err(
             &mut env,
             &mut app_2,
-            Request::SData(SDataRequest::Mutate(SDataMutationOperation {
+            Request::SData(SDataRequest::Mutate(SDataWriteOp {
                 address,
                 crdt_op: entries_op.crdt_op,
             })),
@@ -2210,7 +2210,7 @@ fn sequence_set_owner() {
     common::perform_mutation(
         &mut env,
         &mut client,
-        Request::SData(SDataRequest::MutateOwner(SDataMutationOperation {
+        Request::SData(SDataRequest::SetOwner(SDataWriteOp {
             address,
             crdt_op: owner_op.crdt_op,
         })),
@@ -2278,7 +2278,7 @@ fn sequence_set_pub_permissions() -> Result<()> {
     common::perform_mutation(
         &mut env,
         &mut client,
-        Request::SData(SDataRequest::MutatePubPermissions(SDataMutationOperation {
+        Request::SData(SDataRequest::SetPubPermissions(SDataWriteOp {
             address,
             crdt_op: perms_op.crdt_op,
         })),
@@ -2363,12 +2363,10 @@ fn sequence_set_priv_permissions() -> Result<()> {
     common::perform_mutation(
         &mut env,
         &mut client,
-        Request::SData(SDataRequest::MutatePrivPermissions(
-            SDataMutationOperation {
-                address,
-                crdt_op: perms_op.crdt_op,
-            },
-        )),
+        Request::SData(SDataRequest::SetPrivPermissions(SDataWriteOp {
+            address,
+            crdt_op: perms_op.crdt_op,
+        })),
     );
 
     common::send_request_expect_ok(
@@ -2456,7 +2454,7 @@ fn sequence_set_owners() -> Result<()> {
     common::send_request_expect_err(
         &mut env,
         &mut client_b,
-        Request::SData(SDataRequest::MutateOwner(SDataMutationOperation {
+        Request::SData(SDataRequest::SetOwner(SDataWriteOp {
             address,
             crdt_op: owner_op.crdt_op.clone(),
         })),
@@ -2466,7 +2464,7 @@ fn sequence_set_owners() -> Result<()> {
     common::perform_mutation(
         &mut env,
         &mut client_a,
-        Request::SData(SDataRequest::MutateOwner(SDataMutationOperation {
+        Request::SData(SDataRequest::SetOwner(SDataWriteOp {
             address,
             crdt_op: owner_op.crdt_op,
         })),
@@ -2536,7 +2534,7 @@ fn sequence_append_to_public() -> Result<()> {
     common::perform_mutation(
         &mut env,
         &mut client_a,
-        Request::SData(SDataRequest::Mutate(SDataMutationOperation {
+        Request::SData(SDataRequest::Mutate(SDataWriteOp {
             address: *pub_sdata.address(),
             crdt_op: entries_op.crdt_op,
         })),
@@ -2592,7 +2590,7 @@ fn sequence_append_to_private() -> Result<()> {
     common::perform_mutation(
         &mut env,
         &mut client_a,
-        Request::SData(SDataRequest::Mutate(SDataMutationOperation {
+        Request::SData(SDataRequest::Mutate(SDataWriteOp {
             address: *priv_sdata.address(),
             crdt_op: entries_op.crdt_op,
         })),
@@ -2650,7 +2648,7 @@ fn sequence_append_concurrently_from_diff_clients() -> Result<()> {
     common::perform_mutation(
         &mut env,
         &mut client_b,
-        Request::SData(SDataRequest::Mutate(SDataMutationOperation {
+        Request::SData(SDataRequest::Mutate(SDataWriteOp {
             address: *pub_sdata.address(),
             crdt_op: entries_op.crdt_op,
         })),
@@ -2660,7 +2658,7 @@ fn sequence_append_concurrently_from_diff_clients() -> Result<()> {
     common::perform_mutation(
         &mut env,
         &mut client_a,
-        Request::SData(SDataRequest::Mutate(SDataMutationOperation {
+        Request::SData(SDataRequest::Mutate(SDataWriteOp {
             address: *pub_sdata.address(),
             crdt_op: entries_op.crdt_op,
         })),
@@ -2670,7 +2668,7 @@ fn sequence_append_concurrently_from_diff_clients() -> Result<()> {
     common::perform_mutation(
         &mut env,
         &mut client_b,
-        Request::SData(SDataRequest::Mutate(SDataMutationOperation {
+        Request::SData(SDataRequest::Mutate(SDataWriteOp {
             address: *pub_sdata.address(),
             crdt_op: entries_op.crdt_op,
         })),


### PR DESCRIPTION
- Replaces Get/Mutation with Read/Write,
 as a first step of Request structure refactor.
 - MutableData not included as it is still due for CRDT refactor.

Draft until corresponding `safe-nd` PR is merged (for force pushing update to `Cargo.toml`).