### PR TITLE
Refactor CI, add scheduled audit, and deploy `latest` to S3 for CI use

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,7 +4,6 @@
 #
 # 1. Generates a release build.
 # 2. If the last commit is a version change, publish.
-# 3. Gather coverage stats and push to coveralls.io
 
 name: Master
 
@@ -34,33 +33,32 @@ jobs:
             build-script: make build
             target: x86_64-apple-darwin
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
       # Cache.
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run build.
       - shell: bash
         run: ${{ matrix.build-script }}
+
       # Upload artifacts.
       - uses: actions/upload-artifact@master
         with:
@@ -78,55 +76,36 @@ jobs:
             build-script: make musl
             target: x86_64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
       # Cache.
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run build.
       - shell: bash
         run: ${{ matrix.build-script }}
+
       # Upload artifacts.
       - uses: actions/upload-artifact@master
         with:
           name: safe_vault-${{ matrix.target }}-prod
           path: artifacts
-
-      # Run cargo tarpaulin & push result to coveralls.io
-      - name: rust-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1.0
-        with:
-          args: '--features=mock_parsec --out Lcov -- --test-threads 1'
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: ./lcov.info
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
 
   # Unfortunately, for artifact retrieval, there's not really a way to avoid having this huge list of
   # 'download-artifact' actions. We could perhaps implement our own 'retrieve all build artifacts'
@@ -142,7 +121,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       # Checkout and get all the artifacts built in the previous jobs.
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@master
         with:
           name: safe_vault-x86_64-pc-windows-msvc-prod
@@ -253,7 +232,10 @@ jobs:
   #   needs: deploy
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v1
+  #     - uses: actions/checkout@v2
+  #       # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
+  #       with:
+  #         fetch-depth: '0'
   #     # Is this a version change commit?
   #     - shell: bash
   #       id: commit_message

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,7 +81,7 @@ jobs:
       - name: rust-tarpaulin code coverage check
         uses: actions-rs/tarpaulin@master
         with:
-          args: '-v --release --out Lcov'
+          args: '-v --features=mock_parsec --out Lcov'
       - name: Push code coverage results to coveralls.io
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,8 @@ jobs:
     name: Rustfmt-Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         name: Install Rust & required components
         with:
@@ -26,43 +27,72 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
       # Check if the code is formatted correctly.
       - name: Check formatting
         run: cargo fmt --all -- --check
-
-      # Cache.
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-
-      # Run cargo tarpaulin & push result to coveralls.io
-      - name: rust-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1.0
-        with:
-          args: '--features=mock_parsec --out Lcov -- --test-threads 1'
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: ./lcov.info
 
       # Run Clippy.
       - name: Clippy checks
         shell: bash
         run: ./scripts/clippy
+
+  coverage:
+    name: Code coverage check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust and required components
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
+      # Run cargo tarpaulin & push result to coveralls.io
+      - name: rust-tarpaulin code coverage check
+        uses: actions-rs/tarpaulin@master
+        with:
+          args: '-v --release --out Lcov'
+      - name: Push code coverage results to coveralls.io
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          path-to-lcov: ./lcov.info
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
 
   test:
     name: Test
@@ -71,7 +101,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -79,34 +109,21 @@ jobs:
           toolchain: stable
           override: true
 
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
       # Cache.
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run tests.
       - name: Run tests
         shell: bash
         run: ./scripts/tests
-
-  coverage:
-    needs: [clippy, test]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,0 +1,12 @@
+name: Security audit
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -87,17 +87,29 @@ package-version-artifacts-for-deploy:
 
 	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.zip \
 		artifacts/prod/x86_64-unknown-linux-musl/release/safe_vault
+	zip -j safe_vault-latest-x86_64-unknown-linux-musl.zip \
+		artifacts/prod/x86_64-unknown-linux-musl/release/safe_vault
 	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-msvc.zip \
 		artifacts/prod/x86_64-pc-windows-msvc/release/safe_vault.exe
+	zip -j safe_vault-latest-x86_64-pc-windows-msvc.zip \
+		artifacts/prod/x86_64-pc-windows-msvc/release/safe_vault.exe
 	zip -j safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.zip \
+		artifacts/prod/x86_64-apple-darwin/release/safe_vault
+	zip -j safe_vault-latest-x86_64-apple-darwin.zip \
 		artifacts/prod/x86_64-apple-darwin/release/safe_vault
 
 	tar -C artifacts/prod/x86_64-unknown-linux-musl/release \
 		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-unknown-linux-musl.tar.gz safe_vault
+	tar -C artifacts/prod/x86_64-unknown-linux-musl/release \
+		-zcvf safe_vault-latest-x86_64-unknown-linux-musl.tar.gz safe_vault
 	tar -C artifacts/prod/x86_64-pc-windows-msvc/release \
 		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-pc-windows-msvc.tar.gz safe_vault.exe
+	tar -C artifacts/prod/x86_64-pc-windows-msvc/release \
+		-zcvf safe_vault-latest-x86_64-pc-windows-msvc.tar.gz safe_vault.exe
 	tar -C artifacts/prod/x86_64-apple-darwin/release \
 		-zcvf safe_vault-${SAFE_VAULT_VERSION}-x86_64-apple-darwin.tar.gz safe_vault
+	tar -C artifacts/prod/x86_64-apple-darwin/release \
+		-zcvf safe_vault-latest-x86_64-apple-darwin.tar.gz safe_vault
 
 	mv *.zip ${DEPLOY_PROD_PATH}
 	mv *.tar.gz ${DEPLOY_PROD_PATH}


### PR DESCRIPTION
Updated version of the checkout action being used to v2.
Tidied and condensed the caching.
Added a checkout depth of '0' when adding a tag to the repo to
ensure all commits are retrieved.
Switched the code coverage to it's own job so it can run in
parallel, and set it to only run against PRs.
Added a scheduled security audit.

UPDATE - in order to support CI cross multiple repos where we want to pull the latest released vault I've also added a commit where I've updated the release CI to publish a version of each zip & tar with `latest` alongside the file with a version number. Example of a PR currently in flight which will use this can be viewed [here](https://github.com/maidsafe/safe-client-libs/pull/1224/files#diff-d9db351496552ae42395e3057e47624eR12).
This change will mean we don't need to update multiple CI file vault version numbers manually after each vault release.