### PR TITLE
Fix misleading vault messages

### DIFF
--- a/src/vault.rs
+++ b/src/vault.rs
@@ -391,11 +391,14 @@ impl<R: CryptoRng + Rng> Vault<R> {
             }
             RoutingEvent::Connected(_) => self.promote_to_adult().map_or_else(
                 |err| {
-                    error!("Error when promoting Vault to Adult: {:?}", err);
+                    error!(
+                        "Error creating required components for an Adult vault: {:?}",
+                        err
+                    );
                     None
                 },
                 |()| {
-                    info!("Vault promoted to Adult");
+                    info!("Section has accepted the vault.");
                     None
                 },
             ),


### PR DESCRIPTION
Until maidsafe/routing#2156 is complete we don't know when the Vault was promoted to an Adult state.
`Event::Connected` let's us know when the Vault was accepted into the section. This PR changes the message accordingly.+