### PR TITLE
feat(farming): add some temp calcs of base cost

### DIFF
--- a/scripts/clippy
+++ b/scripts/clippy
@@ -2,6 +2,4 @@
 
 set -e -x
 
-cargo clippy "$@" --all-targets
-# cargo clippy "$@" --all-targets --features=mock --no-default-features
-cargo clippy "$@" --all-targets --features=mock_parsec --no-default-features
+cargo clippy "$@" --all-targets -- -D warnings

--- a/scripts/tests
+++ b/scripts/tests
@@ -2,5 +2,4 @@
 
 set -e -x
 
-cargo test "$@" --release
-# cargo test "$@" --release --features=mock --no-default-features
+RUSTFLAGS="-D warnings" cargo test "$@" --release

--- a/src/node/economy.rs
+++ b/src/node/economy.rs
@@ -19,11 +19,11 @@ pub struct Indicator {
     pub period_key: PublicKey,
     /// The velocity is a scaling
     /// factor which determines the net money issuance.
-    pub minting_velocity: u8,
+    pub minting_velocity: f64,
     /// Used to calculate the store cost
     /// to be used during a period
     /// (i.e. a specific Elder constellation).
-    pub period_cost_base: Money,
+    pub period_base_cost: Money,
 }
 
 /// MintingMetrics are valid through
@@ -41,5 +41,5 @@ pub struct MintingMetrics {
     pub store_cost: Money,
     /// The velocity is a scaling
     /// factor which determines the net money issuance.
-    pub velocity: u8,
+    pub velocity: f64,
 }

--- a/src/node/elder_duties/data_section/metadata/mod.rs
+++ b/src/node/elder_duties/data_section/metadata/mod.rs
@@ -45,6 +45,7 @@ use writing::Writing;
 pub struct Metadata {
     keys: NodeKeys,
     elder_stores: ElderStores,
+    #[allow(unused)]
     wrapping: ElderMsgWrapping,
 }
 

--- a/src/node/elder_duties/data_section/mod.rs
+++ b/src/node/elder_duties/data_section/mod.rs
@@ -38,6 +38,7 @@ pub struct DataSection {
     /// Rewards for performing storage
     /// services to the network.
     rewards: Rewards,
+    #[allow(dead_code)]
     /// The transport layer.
     routing: Rc<RefCell<Routing>>,
 }
@@ -75,6 +76,7 @@ impl DataSection {
         }
     }
 
+    #[allow(dead_code)]
     // Transition the section funds account to the new key.
     pub fn elders_changed(&mut self) -> Option<NodeOperation> {
         let pub_key_set = self.routing.borrow().public_key_set().ok()?.clone();

--- a/src/node/elder_duties/data_section/rewards/mod.rs
+++ b/src/node/elder_duties/data_section/rewards/mod.rs
@@ -65,7 +65,7 @@ impl Rewards {
             minting_metrics: MintingMetrics {
                 key: keys.public_key(),
                 store_cost: base_cost,
-                velocity: 2,
+                velocity: 2.0,
             },
             wrapping,
         }
@@ -219,7 +219,7 @@ impl Rewards {
     fn accumulate_reward(&mut self, points: u64, msg_id: MessageId) -> Option<MessagingDuty> {
         let hash = (msg_id.0).0.to_vec(); // todo: fix the parameter type down-streams (in safe-farming)
         let factor = self.minting_metrics.velocity;
-        match self.farming.reward(hash, points, factor as f64) {
+        match self.farming.reward(hash, points, factor) {
             Ok(amount) => {
                 info!(
                     "Rewarded {} for {} points by write id {:?}.",

--- a/src/node/elder_duties/data_section/rewards/mod.rs
+++ b/src/node/elder_duties/data_section/rewards/mod.rs
@@ -71,6 +71,7 @@ impl Rewards {
         }
     }
 
+    #[allow(dead_code)]
     pub fn transition(&mut self, to: TransferActor<Validator>) -> Option<NodeOperation> {
         Some(self.section_funds.transition(to)?.into())
     }

--- a/src/node/elder_duties/data_section/rewards/section_funds.rs
+++ b/src/node/elder_duties/data_section/rewards/section_funds.rs
@@ -32,6 +32,7 @@ impl SectionFunds {
         }
     }
 
+    #[allow(dead_code)]
     /// At Elder churn, we must transition to a new account.
     pub fn transition(&mut self, to: TransferActor<Validator>) -> Option<MessagingDuty> {
         // TODO:

--- a/src/node/elder_duties/key_section/payment/calc.rs
+++ b/src/node/elder_duties/key_section/payment/calc.rs
@@ -32,8 +32,8 @@ impl Economy {
         let mut instance = Self {
             indicator: Indicator {
                 period_key: section_account,
-                minting_velocity: 2,
-                period_cost_base: Money::zero(),
+                minting_velocity: 2.0,
+                period_base_cost: Money::zero(),
             },
             routing,
             replica,
@@ -42,6 +42,9 @@ impl Economy {
         instance
     }
 
+    /// The calculations within this method
+    /// are temporary and should not be considered
+    /// a final solution. It's something to work with during test nets.
     pub fn update_indicator(&mut self) -> Option<Indicator> {
         let routing = self.routing.borrow();
         let prefix = routing.our_prefix()?;
@@ -54,23 +57,36 @@ impl Economy {
         // Apprx. number of nodes in the network.
         let total_nodes = total_sections * (adult_count + elder_count);
 
+        // The portion of total supply, that this section responsible for.
+        let section_portion = (u32::MAX as u64 * NANOS / total_sections) as f64;
         let section_account = PublicKey::Bls(self.replica.borrow().replicas_pk_set()?.public_key());
+        // The actual balance of this section.
         let section_balance = self.replica.borrow().balance(&section_account)?.as_nano() as f64;
 
-        let section_portion = (u32::MAX as u64 * NANOS / total_sections) as f64;
+        // Percentages of farmed and unfarmed.
         let unfarmed_percent = section_balance / section_portion;
         let farmed_percent = 1.0 - unfarmed_percent;
-        // This is the basis for store cost during the period.
-        let period_cost_base =
-            Money::from_nano(section_balance as u64 / (total_nodes * total_nodes) / NANOS);
+
         // This is the factor that determines how fast new money should be minted.
-        let minting_velocity = (unfarmed_percent / farmed_percent) as u8;
+        // Faster when less is farmed, slower when more is farmed.
+        let minting_velocity = unfarmed_percent / farmed_percent;
+
+        // Some obscure tricks to get the base cost within reasonable values
+        // for very small as well as very large networks (up to about 130 billion nodes).
+        let numerator = 1 / (total_nodes * total_nodes) / NANOS;
+        let denominator = (minting_velocity.powf(prefix_len as f64) + (1.0 / NANOS as f64)) * 1.0
+            / (NANOS as f64).powf(0.5);
+
+        // This is the basis for store cost during the period.
+        let period_base_cost = u64::max(1, (numerator as f64 / denominator) as u64);
+        let period_base_cost = Money::from_nano(period_base_cost);
 
         self.indicator = Indicator {
             period_key: section_account,
-            period_cost_base,
+            period_base_cost,
             minting_velocity,
         };
+
         Some(self.indicator.clone())
     }
 }

--- a/src/node/elder_duties/key_section/payment/mod.rs
+++ b/src/node/elder_duties/key_section/payment/mod.rs
@@ -67,7 +67,7 @@ impl Payments {
 
     pub fn update_costs(&mut self) -> Option<NodeOperation> {
         let indicator = self.calc.update_indicator()?;
-        let cost_base = indicator.period_cost_base.as_nano();
+        let cost_base = indicator.period_base_cost.as_nano();
         let load = self.counter as f64 / self.previous_counter as f64;
         let store_cost = load * cost_base as f64;
         self.store_cost = Money::from_nano(store_cost as u64);

--- a/src/node/elder_duties/key_section/transfers/mod.rs
+++ b/src/node/elder_duties/key_section/transfers/mod.rs
@@ -128,7 +128,7 @@ impl Transfers {
         use TransferCmd::*;
         match cmd {
             #[cfg(feature = "simulated-payouts")]
-            /// Cmd to simulate a farming payout
+            // Cmd to simulate a farming payout
             SimulatePayout(transfer) => self
                 .replica
                 .borrow_mut()
@@ -319,6 +319,7 @@ impl Transfers {
         self.wrapping.send(message)
     }
 
+    #[allow(unused)]
     #[cfg(feature = "simulated-payouts")]
     pub fn pay(&mut self, transfer: Transfer) {
         self.replica.borrow_mut().debit_without_proof(transfer)

--- a/src/node/elder_duties/key_section/transfers/replica_manager.rs
+++ b/src/node/elder_duties/key_section/transfers/replica_manager.rs
@@ -20,9 +20,7 @@ use routing::SectionProofChain;
 use {
     crate::node::node_ops::MessagingDuty,
     rand::thread_rng,
-    safe_nd::{
-        Address, MessageId, PublicId, PublicKey, Signature, SignatureShare, Transfer, XorName,
-    },
+    safe_nd::{PublicKey, Signature, SignatureShare, Transfer},
     threshold_crypto::{SecretKey, SecretKeySet},
 };
 

--- a/src/node/section_querying.rs
+++ b/src/node/section_querying.rs
@@ -45,6 +45,7 @@ impl SectionQuerying {
             .unwrap_or(false)
     }
 
+    #[allow(unused)]
     pub fn our_elder_names(&self) -> Vec<XorName> {
         self.routing
             .borrow_mut()

--- a/src/node/state_db.rs
+++ b/src/node/state_db.rs
@@ -18,6 +18,7 @@ use std::{
 const STATE_FILENAME: &str = "state";
 
 /// Writes the info to disk.
+#[allow(unused)]
 pub fn dump_state(age_group: AgeGroup, root_dir: &Path, id: &NodeKeypairs) -> Result<()> {
     let path = root_dir.join(STATE_FILENAME);
     Ok(fs::write(path, utils::serialise(&(age_group, id)))?)


### PR DESCRIPTION
- NB: Do not consider this a final solution.
- Adds some obscure tricks to the calculations as to bring the store cost values within
some reasonable limits for both very small and very large networks.
- Fixes the last clippy errors.