### PR TITLE
fix(minting_velocity): don't stop at 50% minted

### DIFF
--- a/src/node/elder_duties/key_section/client_msg_analysis.rs
+++ b/src/node/elder_duties/key_section/client_msg_analysis.rs
@@ -61,17 +61,13 @@ impl ClientMsgAnalysis {
     /// by the client and validated by its replicas,
     /// so there is no reason to accumulate it here.
     fn try_data_payment(&self, msg: &MsgEnvelope) -> Option<PaymentDuty> {
-        let from_client = || match msg.origin {
-            MsgSender::Client { .. } => true,
-            _ => false,
-        };
+        let from_client = || matches!(msg.origin, MsgSender::Client { .. });
 
-        let is_data_write = || match msg.message {
-            Message::Cmd {
+        let is_data_write = || {
+            matches!(msg.message, Message::Cmd {
                 cmd: Cmd::Data { .. },
                 ..
-            } => true,
-            _ => false,
+            })
         };
 
         let shall_process =
@@ -85,10 +81,7 @@ impl ClientMsgAnalysis {
     }
 
     fn try_transfers(&self, msg: &MsgEnvelope) -> Option<TransferDuty> {
-        let from_client = || match msg.origin {
-            MsgSender::Client { .. } => true,
-            _ => false,
-        };
+        let from_client = || matches!(msg.origin, MsgSender::Client { .. });
 
         let shall_process = |msg| from_client() && self.is_dst_for(msg) && self.is_elder();
 

--- a/src/node/elder_duties/key_section/payment/calc.rs
+++ b/src/node/elder_duties/key_section/payment/calc.rs
@@ -66,16 +66,18 @@ impl Economy {
         // Percentages of farmed and unfarmed.
         let unfarmed_percent = section_balance / section_portion;
         let farmed_percent = 1.0 - unfarmed_percent;
+        let ratio = unfarmed_percent / farmed_percent;
 
         // This is the factor that determines how fast new money should be minted.
-        // Faster when less is farmed, slower when more is farmed.
-        let minting_velocity = unfarmed_percent / farmed_percent;
+        // Faster when less has been minted, slower when more has been minted.
+        // Will keep minting until all is minted.
+        let minting_velocity = (ratio + 1.0).powf(2.0);
 
         // Some obscure tricks to get the base cost within reasonable values
         // for very small as well as very large networks (up to about 130 billion nodes).
         let numerator = 1 / (total_nodes * total_nodes) / NANOS;
-        let denominator = (minting_velocity.powf(prefix_len as f64) + (1.0 / NANOS as f64)) * 1.0
-            / (NANOS as f64).powf(0.5);
+        let denominator =
+            (ratio.powf(prefix_len as f64) + (1.0 / NANOS as f64)) / (NANOS as f64).powf(0.5);
 
         // This is the basis for store cost during the period.
         let period_base_cost = u64::max(1, (numerator as f64 / denominator) as u64);

--- a/src/node/section_querying.rs
+++ b/src/node/section_querying.rs
@@ -99,19 +99,11 @@ impl SectionQuerying {
     }
 
     pub fn is_elder(&self) -> bool {
-        if let AgeGroup::Elder = self.our_duties() {
-            true
-        } else {
-            false
-        }
+        matches!(self.our_duties(), AgeGroup::Elder)
     }
 
     pub fn is_adult(&self) -> bool {
-        if let AgeGroup::Adult = self.our_duties() {
-            true
-        } else {
-            false
-        }
+        matches!(self.our_duties(), AgeGroup::Adult)
     }
 
     fn our_duties(&self) -> AgeGroup {


### PR DESCRIPTION
- Previous calc for velocity would switch over to net recycling after
50% was minted, which meant that 50% would never come into circulation.
- This change makes minting continue (albeit slower and slower) until
100% is in circulation.