### PR TITLE
Add None variant to break infinite loop

### DIFF
--- a/src/node/elder_duties/key_section/transfers/mod.rs
+++ b/src/node/elder_duties/key_section/transfers/mod.rs
@@ -307,9 +307,6 @@ impl Transfers {
         // We will just validate the proofs and then apply the event.
         let message = match self.replica.borrow_mut().receive_propagated(proof) {
             Ok(_) => return None,
-            // self.send(Message {
-            //     event: Event::TransferReceived
-            // }),
             Err(err) => Message::NodeCmdError {
                 error: NodeCmdError::Transfers(TransferPropagation(err)),
                 id: MessageId::new(),

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -151,6 +151,7 @@ impl<R: CryptoRng + Rng> Node<R> {
                         .collect::<Vec<_>>()
                         .into(),
                 ),
+                None => break,
             }
         }
     }

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -43,16 +43,22 @@ pub enum NodeOperation {
     /// Multiple operations, that will
     /// be carried out sequentially.
     Multiple(Vec<NetworkDuty>),
+    // No op.
+    None,
 }
 
 impl NodeOperation {
     fn from_many(ops: Vec<NodeOperation>) -> NodeOperation {
         use NodeOperation::*;
+        if ops.is_empty() {
+            return None;
+        }
         let multiple = ops
             .into_iter()
             .map(|c| match c {
                 Single(duty) => vec![duty],
                 Multiple(duties) => duties,
+                None => vec![],
             })
             .flatten()
             .collect();


### PR DESCRIPTION
- Node processing of `NodeOperation` would go into infinite loop as the
while condition just expected some, even if the ops vec was empty.
- Now, the `Into` impl will return a `None` variant for `NodeOperation` when the vec
is empty, and the while loop will break at variant `None`.