### PR TITLE
feat(transfers): keep key subset at replicas on section split

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -78,7 +78,10 @@ quick_error! {
         /// Account doesn't exist.
         NoSuchAccount {}
         /// Logic error.
-        Logic {}
+        Logic {
+            display("Logic error")
+            from()
+        }
     }
 }
 

--- a/src/node/elder_duties/data_section/mod.rs
+++ b/src/node/elder_duties/data_section/mod.rs
@@ -84,6 +84,11 @@ impl DataSection {
         self.rewards.transition(actor)
     }
 
+    // At section split, all Elders get their reward payout.
+    pub fn section_split(&mut self) -> Option<NodeOperation> {
+        None
+    }
+
     pub fn relocated_member_joined(
         &mut self,
         old_node_id: XorName,

--- a/src/node/node_duties/network_events.rs
+++ b/src/node/node_duties/network_events.rs
@@ -85,16 +85,18 @@ impl NetworkEvents {
                 );
                 self.evaluate_msg(content)
             }
-            RoutingEvent::EldersChanged { key, elders, .. } => {
-                Some(
-                    ProcessElderChange {
-                        //prefix,
-                        key: PublicKey::Bls(key),
-                        elders: elders.into_iter().map(|e| XorName(e.0)).collect(),
-                    }
-                    .into(),
-                )
-            }
+            RoutingEvent::EldersChanged {
+                key,
+                elders,
+                prefix,
+            } => Some(
+                ProcessElderChange {
+                    prefix,
+                    key: PublicKey::Bls(key),
+                    elders: elders.into_iter().map(|e| XorName(e.0)).collect(),
+                }
+                .into(),
+            ),
             // Ignore all other events
             _ => None,
         }

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -10,7 +10,7 @@
 use safe_nd::Transfer;
 
 use crate::node::economy::MintingMetrics;
-use routing::{event::Event as NetworkEvent, TransportEvent as ClientEvent};
+use routing::{event::Event as NetworkEvent, Prefix, TransportEvent as ClientEvent};
 use safe_nd::{
     AccountId, Address, AuthCmd, DebitAgreementProof, HandshakeResponse, MessageId, MsgEnvelope,
     MsgSender, PaymentQuery, PublicId, PublicKey, ReplicaEvent, RewardCounter, SignedTransfer,
@@ -223,8 +223,8 @@ pub enum ElderDuty {
     /// changes as well, which leads to necessary updates
     /// of various places using the multisig of the section.
     ProcessElderChange {
-        // /// The prefix of our section.
-        // prefix: Prefix,
+        /// The prefix of our section.
+        prefix: Prefix,
         /// The BLS public key of our section.
         key: PublicKey,
         /// The set of elders of our section.

--- a/src/to_db_key.rs
+++ b/src/to_db_key.rs
@@ -10,7 +10,7 @@ use crate::utils;
 use safe_nd::{
     BlobAddress, ClientPublicId, MapAddress, PublicId, PublicKey, SequenceAddress, XorName,
 };
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 
 pub(crate) trait ToDbKey: Serialize {
     /// The encoded string representation of an identifier, used as a key in the context of a
@@ -19,6 +19,11 @@ pub(crate) trait ToDbKey: Serialize {
         let serialised = utils::serialise(&self);
         base64::encode(&serialised)
     }
+}
+
+pub fn from_db_key<T: DeserializeOwned>(key: &str) -> Option<T> {
+    let decoded = base64::decode(key).ok()?;
+    utils::deserialise(&decoded)
 }
 
 impl ToDbKey for SequenceAddress {}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,7 +12,7 @@ use pickledb::{PickleDb, PickleDbDumpPolicy};
 use rand::{distributions::Standard, CryptoRng, Rng};
 use routing::Node as Routing;
 use safe_nd::{BlsKeypairShare, Keypair, PublicId, PublicKey};
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use std::{cell::RefCell, fs, path::Path, rc::Rc};
 use threshold_crypto::{self, serde_impl::SerdeSecret};
 use unwrap::unwrap;
@@ -46,6 +46,10 @@ pub(crate) fn random_vec<R: CryptoRng + Rng>(rng: &mut R, size: usize) -> Vec<u8
 
 pub(crate) fn serialise<T: Serialize>(data: &T) -> Vec<u8> {
     unwrap!(bincode::serialize(data))
+}
+
+pub(crate) fn deserialise<T: DeserializeOwned>(bytes: &[u8]) -> T {
+    unwrap!(bincode::deserialize(bytes))
 }
 
 /// Returns the client's or app's public key if `public_id` represents a Client or App respectively,


### PR DESCRIPTION
 - When section splits, the Replicas in either resulting section
also split the responsibility of the accounts.
Thus, both Replica groups need to drop the accounts that
the other group is now responsible for.