### PR TITLE
feat(rewards): payout rewards to elders on split

### DIFF
--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -150,6 +150,7 @@ impl<R: CryptoRng + Rng> KeySection<R> {
     }
 
     pub fn section_split(&mut self, prefix: Prefix) -> Option<NodeOperation> {
+        // Removes accounts that are no longer our section responsibility.
         let not_matching = |key: AccountId| {
             let xorname: XorName = key.into();
             !prefix.matches(&routing::XorName(xorname.0))

--- a/src/node/elder_duties/mod.rs
+++ b/src/node/elder_duties/mod.rs
@@ -95,11 +95,10 @@ impl<R: CryptoRng + Rng> ElderDuties<R> {
         ];
 
         if prefix != self.prefix {
+            // section has split!
             self.prefix = prefix;
-            // drops accounts
             ops.push(self.key_section.section_split(prefix));
-            // pays rewards to Elders
-            ops.push(self.data_section.section_split());
+            ops.push(self.data_section.section_split(prefix));
         }
 
         Some(ops.into())

--- a/src/node/section_querying.rs
+++ b/src/node/section_querying.rs
@@ -9,7 +9,8 @@
 use crate::node::state_db::AgeGroup;
 use routing::Node as Routing;
 use safe_nd::XorName;
-use std::{cell::RefCell, net::SocketAddr, rc::Rc};
+use std::{cell::RefCell, collections::BTreeSet, net::SocketAddr, rc::Rc};
+use threshold_crypto::PublicKeySet;
 
 /// Querying of our section's member
 /// composition, and other section related things.
@@ -25,6 +26,10 @@ impl SectionQuerying {
 
     pub fn our_name(&self) -> XorName {
         XorName(self.routing.borrow().id().name().0)
+    }
+
+    pub fn public_key_set(&self) -> Option<PublicKeySet> {
+        Some(self.routing.borrow().public_key_set().ok()?.clone())
     }
 
     /// This can be asked for anything that has an XorName.
@@ -45,13 +50,12 @@ impl SectionQuerying {
             .unwrap_or(false)
     }
 
-    #[allow(unused)]
-    pub fn our_elder_names(&self) -> Vec<XorName> {
+    pub fn our_elder_names(&self) -> BTreeSet<XorName> {
         self.routing
             .borrow_mut()
             .our_elders()
             .map(|p2p_node| XorName(p2p_node.name().0))
-            .collect::<Vec<_>>()
+            .collect::<BTreeSet<_>>()
     }
 
     pub fn our_elder_addresses(&self) -> Vec<(XorName, SocketAddr)> {


### PR DESCRIPTION
- Since Elders eventually will very seldom see any relocations, and in
the end practically not be relocated any more,
we also payout their rewards every time there is a section split.