### PR TITLE
feat(rewards): set node reward wallet at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,7 +1938,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "safe-nd"
 version = "0.10.1"
-source = "git+https://github.com/maidsafe/safe-nd.git?branch=farming#7eef5480e779ec974df0957cdb1067e5e5474428"
+source = "git+https://github.com/maidsafe/safe-nd.git?branch=farming#72c595d8de4fea8cf98c6780c184209c6b996f65"
 dependencies = [
  "bincode",
  "crdts",

--- a/src/node/elder_duties/data_section/mod.rs
+++ b/src/node/elder_duties/data_section/mod.rs
@@ -104,7 +104,7 @@ impl DataSection {
         age: u8,
     ) -> Option<NodeOperation> {
         // Adds the relocated account.
-        let first = self.rewards.process(RewardDuty::AddRelocatedNode {
+        let first = self.rewards.process(RewardDuty::AddRelocatingNode {
             old_node_id,
             new_node_id,
             age,

--- a/src/node/elder_duties/data_section/mod.rs
+++ b/src/node/elder_duties/data_section/mod.rs
@@ -89,10 +89,14 @@ impl DataSection {
         self.rewards.payout_rewards(elders)
     }
 
+    /// When a new node joins, it is registered for receiving rewards.
     pub fn new_node_joined(&mut self, id: XorName) -> Option<NodeOperation> {
         self.rewards.process(RewardDuty::AddNewNode(id))
     }
 
+    /// When a relocated node joins, a DataSection
+    /// has a few different things to do, such as
+    /// pay out rewards and trigger chunk duplication.    
     pub fn relocated_node_joined(
         &mut self,
         old_node_id: XorName,

--- a/src/node/elder_duties/mod.rs
+++ b/src/node/elder_duties/mod.rs
@@ -56,6 +56,7 @@ impl<R: CryptoRng + Rng> ElderDuties<R> {
         self.key_section.catchup_with_section()
     }
 
+    /// Processing of any Elder duty.
     pub fn process(&mut self, duty: ElderDuty) -> Option<NodeOperation> {
         use ElderDuty::*;
         match duty {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -84,7 +84,7 @@ impl<R: CryptoRng + Rng> Node<R> {
             Elder => duties.process(node_ops::NodeDuty::BecomeElder),
         };
 
-        let node = Self {
+        let mut node = Self {
             duties,
             receiver,
             routing,
@@ -95,7 +95,10 @@ impl<R: CryptoRng + Rng> Node<R> {
         Ok(node)
     }
 
-    fn register(&self, _reward_key: PublicKey) {}
+    fn register(&mut self, reward_key: PublicKey) {
+        let result = self.duties.process(NodeDuty::RegisterWallet(reward_key));
+        self.process_while_any(result);
+    }
 
     /// Returns our connection info.
     pub fn our_connection_info(&mut self) -> Result<SocketAddr> {

--- a/src/node/msg_wrapping.rs
+++ b/src/node/msg_wrapping.rs
@@ -10,6 +10,7 @@ use crate::{node::keys::NodeSigningKeys, node::node_ops::MessagingDuty, utils};
 use log::info;
 use safe_nd::{
     Address, AdultDuties, CmdError, Duty, ElderDuties, Message, MessageId, MsgEnvelope, MsgSender,
+    NodeDuties,
 };
 use xor_name::XorName;
 
@@ -28,6 +29,12 @@ pub struct AdultMsgWrapping {
     inner: MsgWrapping,
 }
 
+/// Wrapping of msgs sent by any Node.
+#[derive(Clone)]
+pub struct NodeMsgWrapping {
+    inner: MsgWrapping,
+}
+
 /// Msg wrapping simplifies
 /// the signing and stamping of
 /// a sender duty onto remote msgs
@@ -36,6 +43,17 @@ pub struct AdultMsgWrapping {
 struct MsgWrapping {
     keys: NodeSigningKeys,
     duty: Duty,
+}
+
+impl NodeMsgWrapping {
+    pub fn new(keys: NodeSigningKeys, duty: NodeDuties) -> Self {
+        let inner = MsgWrapping::new(keys, Duty::Node(duty));
+        Self { inner }
+    }
+
+    pub fn send(&self, message: Message) -> Option<MessagingDuty> {
+        self.inner.send(message)
+    }
 }
 
 impl AdultMsgWrapping {

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -95,6 +95,8 @@ pub enum NetworkDuty {
 /// Common duties run by all nodes.
 #[allow(clippy::large_enum_variant)]
 pub enum NodeDuty {
+    ///
+    RegisterWallet(PublicKey),
     /// On being promoted, an Infant node becomes an Adult.
     BecomeAdult,
     /// On being promoted, an Adult node becomes an Elder.
@@ -116,6 +118,7 @@ impl Into<NodeOperation> for NodeDuty {
 impl Debug for NodeDuty {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::RegisterWallet(_) => write!(f, "RegisterWallet"),
             Self::BecomeAdult => write!(f, "BecomeAdult"),
             Self::BecomeElder => write!(f, "BecomeElder"),
             Self::ProcessMessaging(duty) => duty.fmt(f),
@@ -393,10 +396,18 @@ pub enum ChunkDuty {
 pub enum RewardDuty {
     /// With the node id.
     AddNewNode(XorName),
+    /// Set the account for a node.
+    SetNodeAccount {
+        /// The node which accumulated the rewards.
+        node_id: XorName,
+        /// The account to which the accumulated
+        /// rewards should be paid out.
+        account_id: AccountId,
+    },
     /// We add relocated nodes to our rewards
     /// system, so that they can participate
     /// in the farming rewards.
-    AddRelocatedNode {
+    AddRelocatingNode {
         /// The id of the node at the previous section.
         old_node_id: XorName,
         /// The id of the node at its new section (i.e. this one).
@@ -419,7 +430,7 @@ pub enum RewardDuty {
     },
     /// When a node has been relocated to our section
     /// we receive the account id from the other section.
-    ReceiveAccountId {
+    ActivateNodeAccount {
         /// The account to which the accumulated
         /// rewards should be paid out.
         id: AccountId,


### PR DESCRIPTION
- Allows registration of node reward wallet at startup.
- Updates comments for the reward simplification.
- Adds some missing comments.