### PR TITLE
refactor(ci): Refactor of GHA CI files

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,7 +4,6 @@
 #
 # 1. Generates a release build.
 # 2. If the last commit is a version change, publish.
-# 3. Gather coverage stats and push to coveralls.io
 
 name: Master
 
@@ -34,7 +33,9 @@ jobs:
             build-script: make build
             target: x86_64-apple-darwin
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
+      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -42,25 +43,19 @@ jobs:
           override: true
 
       # Cache.
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run build.
       - shell: bash
         run: ${{ matrix.build-script }}
+
       # Upload artifacts.
       - uses: actions/upload-artifact@master
         with:
@@ -78,7 +73,9 @@ jobs:
             build-script: make musl
             target: x86_64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
+      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -86,47 +83,24 @@ jobs:
           override: true
 
       # Cache.
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run build.
       - shell: bash
         run: ${{ matrix.build-script }}
+
       # Upload artifacts.
       - uses: actions/upload-artifact@master
         with:
           name: safe_vault-${{ matrix.target }}-prod
           path: artifacts
-
-      # Run cargo tarpaulin & push result to coveralls.io
-      - name: rust-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1.0
-        with:
-          args: '--features=mock_parsec --out Lcov -- --test-threads 1'
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: ./lcov.info
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
 
   # Unfortunately, for artifact retrieval, there's not really a way to avoid having this huge list of
   # 'download-artifact' actions. We could perhaps implement our own 'retrieve all build artifacts'
@@ -142,7 +116,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       # Checkout and get all the artifacts built in the previous jobs.
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@master
         with:
           name: safe_vault-x86_64-pc-windows-msvc-prod
@@ -167,6 +141,7 @@ jobs:
         run: |
           version=$(grep "^version" < Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
           echo "::set-output name=version::$version"
+
       # Create `deploy` directory and put the artifacts into tar/zip archives for deployment with the release.
       - name: chmod
         shell: bash
@@ -177,6 +152,7 @@ jobs:
       - shell: bash
         run: make package-version-artifacts-for-deploy
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+
       # Get release description (requires generated archives)
       - shell: bash
         id: release_description
@@ -202,6 +178,7 @@ jobs:
           prerelease: false
           body: ${{ steps.release_description.outputs.description }}
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+
       # Upload zip files
       - uses: actions/upload-release-asset@v1.0.1
         with:
@@ -224,6 +201,7 @@ jobs:
           asset_name: safe_vault-${{ steps.versioning.outputs.version }}-x86_64-apple-darwin.zip
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+
       # Upload tar files
       - uses: actions/upload-release-asset@v1.0.1
         with:
@@ -253,7 +231,10 @@ jobs:
   #   needs: deploy
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v1
+  #     - uses: actions/checkout@v2
+  #       # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
+  #       with:
+  #         fetch-depth: '0'
   #     # Is this a version change commit?
   #     - shell: bash
   #       id: commit_message

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,9 @@ jobs:
     name: Rustfmt-Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
+      # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         name: Install Rust & required components
         with:
@@ -26,73 +28,65 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      # Cache
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      
       # Check if the code is formatted correctly.
       - name: Check formatting
         run: cargo fmt --all -- --check
-
-      # Cache.
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       # Run Clippy.
       - name: Clippy checks
         shell: bash
         run: ./scripts/clippy
 
-  tarpaulin:
-      name: Tarpaulin
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v1
-        - uses: actions-rs/toolchain@v1
-          name: Install Rust & required components
-          with:
-            profile: minimal
-            toolchain: stable
+  coverage:
+    name: Code coverage check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-        # Cache.
-        - name: Cache cargo registry
-          uses: actions/cache@v1
-          with:
-            path: ~/.cargo/registry
-            key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        - name: Cache cargo index
-          uses: actions/cache@v1
-          with:
-            path: ~/.cargo/git
-            key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-        - name: Cache cargo build
-          uses: actions/cache@v1
-          with:
-            path: target
-            key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-
-        # Run cargo tarpaulin & push result to coveralls.io
-        - name: rust-tarpaulin
-          uses: actions-rs/tarpaulin@v0.1.0
-          with:
-            args: '--out Lcov -- --test-threads 1'
-        - name: Coveralls GitHub Action
-          uses: coverallsapp/github-action@master
-          with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            parallel: true
-            path-to-lcov: ./lcov.info
-
-
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      
+      # Run cargo tarpaulin & push result to coveralls.io
+      - name: rust-tarpaulin code coverage check
+        uses: actions-rs/tarpaulin@master
+        with:
+          args: '-v --release --out Lcov'
+      - name: Push code coverage results to coveralls.io
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          path-to-lcov: ./lcov.info
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
 
   test:
     name: Test
@@ -101,42 +95,26 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
+
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
       # Cache.
-      - name: Cache cargo registry
-        uses: actions/cache@v1
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run tests.
       - name: Run tests
         shell: bash
         run: ./scripts/tests
-
-  coverage:
-    needs: [test, tarpaulin]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true


### PR DESCRIPTION
Updated version of the checkout action being used to v2.
Tidied and condensed the caching.
Added a checkout depth of '0' when adding a tag to the repo to
ensure all commits are retrieved (though the publish part of the
code is actually commented out at the moment).
Switched the code coverage to it's own job so it can run in
parallel, and set it to only run against PRs.

This refactor was originally done on the old `master` branch but was lost when farming = master. Re-adding.