### PR TITLE
Remove excessive cloning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,7 +2242,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "safe-nd"
 version = "0.11.3"
-source = "git+https://github.com/maidsafe/safe-nd.git?branch=master#39ed587b76c3ef92c6827264d5c8592d66d8abcc"
+source = "git+https://github.com/maidsafe/safe-nd.git#39ed587b76c3ef92c6827264d5c8592d66d8abcc"
 dependencies = [
  "bincode",
  "crdts",

--- a/src/node/adult_duties/chunks/chunk_storage.rs
+++ b/src/node/adult_duties/chunks/chunk_storage.rs
@@ -26,7 +26,7 @@ pub(crate) struct ChunkStorage {
 }
 
 impl ChunkStorage {
-    pub(crate) fn new(node_info: NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
+    pub(crate) fn new(node_info: &NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
         let chunks = BlobChunkStore::new(
             node_info.path(),
             node_info.max_storage_capacity,
@@ -97,13 +97,13 @@ impl ChunkStorage {
 
     pub(crate) fn get(
         &self,
-        address: BlobAddress,
+        address: &BlobAddress,
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
         let result = self
             .chunks
-            .get(&address)
+            .get(address)
             .map_err(|error| error.to_string().into());
         self.wrapping.send(Message::QueryResponse {
             id: MessageId::new(),

--- a/src/node/adult_duties/chunks/mod.rs
+++ b/src/node/adult_duties/chunks/mod.rs
@@ -30,7 +30,7 @@ pub(crate) struct Chunks {
 }
 
 impl Chunks {
-    pub fn new(node_info: NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
+    pub fn new(node_info: &NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
         let chunk_storage = ChunkStorage::new(node_info, total_used_space)?;
 
         Ok(Self { chunk_storage })
@@ -47,10 +47,7 @@ impl Chunks {
             Message::Query {
                 query: Query::Data(DataQuery::Blob(read)),
                 ..
-            } => {
-                let reading = Reading::new(read.clone(), msg.clone());
-                reading.get_result(&self.chunk_storage)
-            }
+            } => Reading::get_result(read, msg, &self.chunk_storage),
             Message::Cmd {
                 cmd:
                     Cmd::Data {
@@ -58,10 +55,7 @@ impl Chunks {
                         ..
                     },
                 ..
-            } => {
-                let writing = Writing::new(write.clone(), msg.clone());
-                writing.get_result(&mut self.chunk_storage)
-            }
+            } => Writing::get_result(write, msg, &mut self.chunk_storage),
             _ => None,
         }
     }

--- a/src/node/adult_duties/chunks/reading.rs
+++ b/src/node/adult_duties/chunks/reading.rs
@@ -22,11 +22,15 @@ impl Reading {
         Self { read, msg }
     }
 
-    pub fn get_result(&self, storage: &ChunkStorage) -> Option<MessagingDuty> {
-        let BlobRead::Get(address) = self.read;
-        if let Address::Section(_) = self.msg.most_recent_sender().address() {
-            if self.verify_msg() {
-                storage.get(address, self.msg.id(), &self.msg.origin)
+    pub fn get_result(
+        read: &BlobRead,
+        msg: &MsgEnvelope,
+        storage: &ChunkStorage,
+    ) -> Option<MessagingDuty> {
+        let BlobRead::Get(address) = read;
+        if let Address::Section(_) = msg.most_recent_sender().address() {
+            if msg.verify() {
+                storage.get(address, msg.id(), &msg.origin)
             } else {
                 error!("Accumulated signature is invalid!");
                 None

--- a/src/node/adult_duties/chunks/writing.rs
+++ b/src/node/adult_duties/chunks/writing.rs
@@ -22,21 +22,25 @@ impl Writing {
         Self { write, msg }
     }
 
-    pub fn get_result(&self, storage: &mut ChunkStorage) -> Option<MessagingDuty> {
+    pub fn get_result(
+        write: &BlobWrite,
+        msg: &MsgEnvelope,
+        storage: &mut ChunkStorage,
+    ) -> Option<MessagingDuty> {
         use BlobWrite::*;
-        match &self.write {
+        match &write {
             New(data) => {
-                if self.verify_msg() {
-                    storage.store(&data, self.msg.id(), &self.msg.origin)
+                if msg.verify() {
+                    storage.store(&data, msg.id(), &msg.origin)
                 } else {
-                    error!("Accumulated signature for {:?} is invalid!", &self.msg.id());
+                    error!("Accumulated signature for {:?} is invalid!", &msg.id());
                     None
                 }
             }
             DeletePrivate(address) => {
-                if self.verify_msg() {
+                if msg.verify() {
                     // really though, for a delete, what we should be looking at is the origin signature! That would be the source of truth!
-                    storage.delete(*address, self.msg.id(), &self.msg.origin)
+                    storage.delete(*address, msg.id(), &msg.origin)
                 } else {
                     error!("Accumulated signature is invalid!");
                     None

--- a/src/node/adult_duties/mod.rs
+++ b/src/node/adult_duties/mod.rs
@@ -27,7 +27,7 @@ pub struct AdultDuties {
 }
 
 impl AdultDuties {
-    pub fn new(node_info: NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
+    pub fn new(node_info: &NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
         let chunks = Chunks::new(node_info, &total_used_space)?;
         Ok(Self { chunks })
     }

--- a/src/node/elder_duties/data_section/metadata/account_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/account_storage.rs
@@ -35,7 +35,7 @@ pub(super) struct AccountStorage {
 
 impl AccountStorage {
     pub fn new(
-        node_info: NodeInfo,
+        node_info: &NodeInfo,
         total_used_space: &Rc<Cell<u64>>,
         wrapping: ElderMsgWrapping,
     ) -> Result<Self> {

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -56,7 +56,7 @@ pub(super) struct BlobRegister {
 
 impl BlobRegister {
     pub(super) fn new(
-        node_info: NodeInfo,
+        node_info: &NodeInfo,
         wrapping: ElderMsgWrapping,
         routing: Network,
     ) -> Result<Self> {

--- a/src/node/elder_duties/data_section/metadata/map_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/map_storage.rs
@@ -32,7 +32,7 @@ pub(super) struct MapStorage {
 
 impl MapStorage {
     pub(super) fn new(
-        node_info: NodeInfo,
+        node_info: &NodeInfo,
         total_used_space: &Rc<Cell<u64>>,
         wrapping: ElderMsgWrapping,
     ) -> Result<Self> {

--- a/src/node/elder_duties/data_section/metadata/mod.rs
+++ b/src/node/elder_duties/data_section/metadata/mod.rs
@@ -49,15 +49,14 @@ pub struct Metadata {
 
 impl Metadata {
     pub fn new(
-        node_info: NodeInfo,
+        node_info: &NodeInfo,
         total_used_space: &Rc<Cell<u64>>,
         routing: Network,
     ) -> Result<Self> {
         let wrapping = ElderMsgWrapping::new(node_info.keys(), ElderDuties::Metadata);
-        let account_storage =
-            AccountStorage::new(node_info.clone(), total_used_space, wrapping.clone())?;
-        let blob_register = BlobRegister::new(node_info.clone(), wrapping.clone(), routing)?;
-        let map_storage = MapStorage::new(node_info.clone(), total_used_space, wrapping.clone())?;
+        let account_storage = AccountStorage::new(node_info, total_used_space, wrapping.clone())?;
+        let blob_register = BlobRegister::new(node_info, wrapping.clone(), routing)?;
+        let map_storage = MapStorage::new(node_info, total_used_space, wrapping.clone())?;
         let sequence_storage = SequenceStorage::new(node_info, total_used_space, wrapping.clone())?;
         let elder_stores = ElderStores::new(
             account_storage,

--- a/src/node/elder_duties/data_section/metadata/sequence_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/sequence_storage.rs
@@ -33,7 +33,7 @@ pub(super) struct SequenceStorage {
 
 impl SequenceStorage {
     pub(super) fn new(
-        node_info: NodeInfo,
+        node_info: &NodeInfo,
         total_used_space: &Rc<Cell<u64>>,
         wrapping: ElderMsgWrapping,
     ) -> Result<Self> {

--- a/src/node/elder_duties/data_section/mod.rs
+++ b/src/node/elder_duties/data_section/mod.rs
@@ -40,15 +40,19 @@ pub struct DataSection {
 
 impl DataSection {
     ///
-    pub fn new(info: NodeInfo, total_used_space: &Rc<Cell<u64>>, routing: Network) -> Result<Self> {
+    pub fn new(
+        info: &NodeInfo,
+        total_used_space: &Rc<Cell<u64>>,
+        routing: Network,
+    ) -> Result<Self> {
         // Metadata
-        let metadata = Metadata::new(info.clone(), &total_used_space, routing.clone())?;
+        let metadata = Metadata::new(info, &total_used_space, routing.clone())?;
 
         // Rewards
         let keypair = utils::key_pair(routing.clone())?;
         let public_key_set = routing.public_key_set()?;
         let actor = TransferActor::new(keypair, public_key_set, Validator {});
-        let rewards = Rewards::new(info.keys, actor);
+        let rewards = Rewards::new(info.keys.clone(), actor);
 
         Ok(Self {
             metadata,

--- a/src/node/elder_duties/key_section/client/mod.rs
+++ b/src/node/elder_duties/key_section/client/mod.rs
@@ -36,7 +36,7 @@ pub struct ClientGateway<R: CryptoRng + Rng> {
 }
 
 impl<R: CryptoRng + Rng> ClientGateway<R> {
-    pub fn new(info: NodeInfo, routing: Network, rng: R) -> Result<Self> {
+    pub fn new(info: &NodeInfo, routing: Network, rng: R) -> Result<Self> {
         let onboarding = Onboarding::new(info.public_key().ok_or(Error::Logic)?, routing.clone());
         let client_msg_tracking = ClientMsgTracking::new(onboarding);
 

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -46,11 +46,11 @@ pub struct KeySection<R: CryptoRng + Rng> {
 }
 
 impl<R: CryptoRng + Rng> KeySection<R> {
-    pub fn new(info: NodeInfo, routing: Network, rng: R) -> Result<Self> {
-        let gateway = ClientGateway::new(info.clone(), routing.clone(), rng)?;
-        let replica_manager = Self::new_replica_manager(info.clone(), routing.clone())?;
+    pub fn new(info: &NodeInfo, routing: Network, rng: R) -> Result<Self> {
+        let gateway = ClientGateway::new(info, routing.clone(), rng)?;
+        let replica_manager = Self::new_replica_manager(info, routing.clone())?;
         let payments = Payments::new(info.keys.clone(), replica_manager.clone());
-        let transfers = Transfers::new(info.keys, replica_manager.clone());
+        let transfers = Transfers::new(info.keys.clone(), replica_manager.clone());
         let msg_analysis = ClientMsgAnalysis::new(routing.clone());
 
         Ok(Self {
@@ -122,7 +122,7 @@ impl<R: CryptoRng + Rng> KeySection<R> {
     }
 
     fn new_replica_manager(
-        info: NodeInfo,
+        info: &NodeInfo,
         routing: Network,
     ) -> Result<Rc<RefCell<ReplicaManager>>> {
         let public_key_set = routing.public_key_set()?;

--- a/src/node/elder_duties/mod.rs
+++ b/src/node/elder_duties/mod.rs
@@ -33,13 +33,13 @@ pub struct ElderDuties<R: CryptoRng + Rng> {
 
 impl<R: CryptoRng + Rng> ElderDuties<R> {
     pub fn new(
-        info: NodeInfo,
+        info: &NodeInfo,
         total_used_space: &Rc<Cell<u64>>,
         routing: Network,
         rng: R,
     ) -> Result<Self> {
         let prefix = routing.our_prefix().ok_or(Error::Logic)?;
-        let key_section = KeySection::new(info.clone(), routing.clone(), rng)?;
+        let key_section = KeySection::new(info, routing.clone(), rng)?;
         let data_section = DataSection::new(info, total_used_space, routing)?;
         Ok(Self {
             prefix,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -56,11 +56,13 @@ impl<R: CryptoRng + Rng> Node<R> {
                 PublicKey::Bls(public)
             }
         };
-        let age_group = get_age_group(&root_dir)?.unwrap_or_else(|| {
-            let age_group = Infant;
-            store_age_group(root_dir, age_group.clone()).unwrap_or(());
+        let age_group = if let Some(age_group) = get_age_group(&root_dir)? {
             age_group
-        });
+        } else {
+            let age_group = Infant;
+            store_age_group(root_dir, &age_group)?;
+            age_group
+        };
 
         let network_api = Network::new(config).await?;
         let keys = NodeSigningKeys::new(network_api.clone());

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -105,7 +105,7 @@ impl<R: CryptoRng + Rng> NodeDuties<R> {
     fn become_adult(&mut self) -> Option<NodeOperation> {
         use DutyLevel::*;
         let total_used_space = Rc::new(Cell::new(0));
-        if let Ok(duties) = AdultDuties::new(self.node_info.clone(), &total_used_space) {
+        if let Ok(duties) = AdultDuties::new(&self.node_info, &total_used_space) {
             self.duty_level = Adult(duties);
             // NB: This is wrong, shouldn't write to disk here,
             // let it be upper layer resp.
@@ -123,7 +123,7 @@ impl<R: CryptoRng + Rng> NodeDuties<R> {
             return None;
         }
         if let Ok(duties) = ElderDuties::new(
-            self.node_info.clone(),
+            &self.node_info,
             &total_used_space,
             self.routing.clone(),
             self.rng.take()?,

--- a/src/node/state_db.rs
+++ b/src/node/state_db.rs
@@ -32,9 +32,9 @@ pub fn store_new_reward_keypair(
 }
 
 /// Writes the info to disk.
-pub fn store_age_group(root_dir: &Path, age_group: AgeGroup) -> Result<()> {
+pub fn store_age_group(root_dir: &Path, age_group: &AgeGroup) -> Result<()> {
     let path = root_dir.join(AGE_GROUP_FILENAME);
-    fs::write(path, utils::serialise(&age_group))?;
+    fs::write(path, utils::serialise(age_group))?;
     Ok(())
 }
 


### PR DESCRIPTION
One change that I still have doubts about is to the Reading and Writing structs in adult duties.
A struct itself might not be required there, so perhaps we can simplify it to be `reading::do_something(....)` and `writing::do_something(...)`. What do you think?