### PR TITLE
Generate and display dependency graphs and check for duplicate deps

### DIFF
--- a/.github/workflows/generate_dependency_graphs.yml
+++ b/.github/workflows/generate_dependency_graphs.yml
@@ -1,0 +1,30 @@
+name: Generate and Deploy Dependency Graph
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Every day at 1 AM
+    - cron:  '0 1 * * *'
+
+jobs:
+  generate-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Install dot
+        run: sudo apt-get install graphviz
+
+      - shell: bash
+        run: ./scripts/generate_dependency_graphs
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: png_generator # The branch the action should deploy to.
+          FOLDER: images # The folder the action should deploy.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -140,3 +140,21 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+
+  # list all duplicate dependencies. Note that this does not error if duplicates found
+  dependencies:
+    name: List Duplicate Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Run list duplicate dependencies script
+      - shell: bash
+        run: ./scripts/duplicate_dependency_check

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SAFE Vault
 
-|Crate|Documentation|Linux/macOS|Windows|Safe Rust|
-|:---:|:-----------:|:---------:|:-----:|:-------:|
-|[![](http://meritbadge.herokuapp.com/safe_vault)](https://crates.io/crates/safe_vault)|[![Documentation](https://docs.rs/safe_vault/badge.svg)](https://docs.rs/safe_vault)|[![Build Status](https://travis-ci.com/maidsafe/safe_vault.svg?branch=master)](https://travis-ci.com/maidsafe/safe_vault)|[![Build status](https://ci.appveyor.com/api/projects/status/ohu678c6ufw8b2bn/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/safe-vault/branch/master)|[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
+|Crate|Documentation|Safe Rust|
+|:---:|:-----------:|:-------:|
+|[![](http://meritbadge.herokuapp.com/safe_vault)](https://crates.io/crates/safe_vault)|[![Documentation](https://docs.rs/safe_vault/badge.svg)](https://docs.rs/safe_vault)|[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
 |:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|
@@ -10,6 +10,33 @@
 ## Overview
 
 An autonomous network capable of data storage/publishing/sharing as well as computation, value transfer (crypto currency support) and more. See the documentation for a more detailed description of the operations involved in data storage.
+
+## Crate Dependencies
+Crate dependencies graph:
+
+![safe_vault MaidSafe dependencies](https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_maidsafe_dependencies.png)
+
+
+### Legend
+Dependencies are coloured depending on their kind:
+* **Black:** regular dependency
+* **Purple:** build dependency
+* **Blue:** dev dependency
+* **Red:** optional dependency
+
+A dependency can be of more than one kind. In such cases, it is coloured with the following priority:
+`Regular -> Build -> Dev -> Optional`
+
+<details>
+<summary> View all safe_vault dependencies</summary>
+<p>
+
+![safe_vault all dependencies](https://github.com/maidsafe/safe_vault/blob/png_generator/safe_vault_all_dependencies.png)
+
+</p>
+</details>
+
+Click [here](https://maidsafe.github.io/interdependency-svg-generator/) for an overview of the interdependencies of all the main MaidSafe components.
 
 ## License
 

--- a/scripts/duplicate_dependency_check
+++ b/scripts/duplicate_dependency_check
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e -x
+
+rm -rf images
+mkdir images
+
+cargo install cargo-tree
+
+cargo tree -d

--- a/scripts/generate_dependency_graphs
+++ b/scripts/generate_dependency_graphs
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e -x
+
+rm -rf images
+mkdir images
+
+cargo install cargo-deps
+
+cargo deps --all-deps --include-orphans --filter safe_vault safe-nd parsec maidsafe_utilities routing mock-quic-p2p quic-p2p lru_time_cache fake_clock xor_name bls_dkg safe-network-signature-aggregator | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/safe_vault_maidsafe_dependencies.png
+cargo deps | dot -T png -o images/safe_vault_all_dependencies.png


### PR DESCRIPTION
The dependency checks and graphs existed on the old `master` branch but was lost when farming = master. Re-adding.