### PR TITLE
chore(ci): switch code coverage check to run against prod code

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,15 +84,13 @@ jobs:
         - name: rust-tarpaulin
           uses: actions-rs/tarpaulin@v0.1.0
           with:
-            args: '--out Lcov -- --test-threads 1'
+            args: '-v --release --out Lcov'
         - name: Coveralls GitHub Action
           uses: coverallsapp/github-action@master
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             parallel: true
             path-to-lcov: ./lcov.info
-
-
 
   test:
     name: Test


### PR DESCRIPTION
Supersedes #1030 

Adding DO NOT MERGE flag until tests are working and switched over to prod