### PR TITLE
chore(deps): update to reference renamed sn_fake_clock crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
 dependencies = [
  "block-cipher-trait",
  "byteorder",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -44,7 +44,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 dependencies = [
  "block-cipher-trait",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -115,13 +115,13 @@ checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "async-trait"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1a4a2f97ce50c9d0282c1468816208588441492b40d813b2e0419c22c05e7f"
+checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf13118df3e3dce4b5ac930641343b91b656e4e72c8f8325838b01a4b1c9d45"
 dependencies = [
  "http",
- "log 0.4.11",
+ "log",
  "url",
 ]
 
@@ -154,9 +154,9 @@ checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
@@ -255,7 +255,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -264,7 +273,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -289,7 +298,8 @@ dependencies = [
 [[package]]
 name = "bls_dkg"
 version = "0.1.0"
-source = "git+https://github.com/maidsafe/BLS-DKG#21c45ec522023a16a0982aed6bd483484d747046"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3650108f1ee951a01970910a971a654121c71a6fda7688d13c56a82dfe898a"
 dependencies = [
  "aes",
  "bincode",
@@ -297,8 +307,8 @@ dependencies = [
  "bytes 0.5.6",
  "crossbeam-channel",
  "err-derive",
- "itertools 0.9.0",
- "log 0.4.11",
+ "itertools",
+ "log",
  "quic-p2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -306,6 +316,22 @@ dependencies = [
  "serde_derive",
  "threshold_crypto",
  "tmp-ed25519",
+]
+
+[[package]]
+name = "bls_signature_aggregator"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a679e22b583a2c5db9ec442746fa5429d0f37753a53bbbc18f73976cc4d8b"
+dependencies = [
+ "bincode",
+ "err-derive",
+ "fake_clock",
+ "log",
+ "rand 0.7.3",
+ "serde",
+ "threshold_crypto",
+ "tiny-keccak 2.0.2",
 ]
 
 [[package]]
@@ -469,6 +495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,7 +538,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "cfg-if",
  "lazy_static",
 ]
@@ -523,7 +555,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
  "subtle 1.0.0",
 ]
 
@@ -554,7 +586,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.8.1",
+ "rand_core 0.5.1",
+ "subtle 2.2.3",
+ "zeroize 1.1.0",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle 2.2.3",
  "zeroize 1.1.0",
@@ -572,7 +617,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dc203b75decc900220c4d9838e738d08413e663c26826ba92b669bed1d0795"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -583,7 +628,7 @@ checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -592,7 +637,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -644,15 +698,15 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
+checksum = "53d2e93f837d749c16d118e7ddf7a4dfd0ac8f452cf51e46e9348824e5ef6851"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.0.0",
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.1",
  "zeroize 1.1.0",
 ]
 
@@ -670,9 +724,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
+checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
 dependencies = [
  "cfg-if",
 ]
@@ -685,7 +739,7 @@ checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.11",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -698,7 +752,7 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.11",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -713,7 +767,7 @@ dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
  "rustversion",
- "syn 1.0.38",
+ "syn 1.0.39",
  "synstructure",
 ]
 
@@ -735,7 +789,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
  "synstructure",
 ]
 
@@ -773,7 +827,7 @@ dependencies = [
  "num-traits",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -782,7 +836,7 @@ version = "0.1.3"
 source = "git+https://github.com/lionel1704/file-per-thread-logger?branch=allow-uninitialized#c5bc37adcfde260577535b2b28e6925441e692bd"
 dependencies = [
  "env_logger 0.7.1",
- "log 0.4.11",
+ "log",
 ]
 
 [[package]]
@@ -817,7 +871,7 @@ checksum = "515fb7f6541dafe542c87c12a7ab6a52190cccb6c348b5951ef62d9978189ae8"
 dependencies = [
  "chrono",
  "glob",
- "log 0.4.11",
+ "log",
  "regex",
  "yansi",
 ]
@@ -917,7 +971,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -974,6 +1028,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,7 +1045,7 @@ checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1048,7 +1112,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1088,7 +1152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.8.1",
 ]
 
 [[package]]
@@ -1161,7 +1225,7 @@ dependencies = [
  "bytes 0.4.12",
  "httparse",
  "language-tags",
- "log 0.4.11",
+ "log",
  "mime",
  "percent-encoding 1.0.1",
  "time",
@@ -1177,7 +1241,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-util",
  "hyper",
- "log 0.4.11",
+ "log",
  "rustls 0.18.1",
  "tokio",
  "tokio-rustls",
@@ -1206,7 +1270,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "log 0.4.11",
+ "log",
  "rand 0.7.3",
  "tokio",
  "url",
@@ -1215,11 +1279,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
+checksum = "4e47a3566dd4fd4eec714ae6ceabdee0caec795be835c223d92c2d40f1e8cf1c"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "hashbrown 0.8.2",
 ]
 
@@ -1249,15 +1313,6 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1331,15 +1386,6 @@ checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.11",
-]
-
-[[package]]
-name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
@@ -1367,7 +1413,7 @@ dependencies = [
  "fnv",
  "humantime",
  "libc",
- "log 0.4.11",
+ "log",
  "log-mdc",
  "serde",
  "serde-value",
@@ -1441,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
+checksum = "4d7559a8a40d0f97e1edea3220f698f78b1c5ab67532e49f68fde3910323b722"
 dependencies = [
  "adler",
 ]
@@ -1460,7 +1506,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.11",
+ "log",
  "miow",
  "net2",
  "slab",
@@ -1474,7 +1520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log 0.4.11",
+ "log",
  "mio",
  "slab",
 ]
@@ -1504,7 +1550,7 @@ dependencies = [
  "crypto-mac",
  "ctr",
  "dbl",
- "generic-array",
+ "generic-array 0.12.3",
  "pmac",
  "stream-cipher",
  "subtle 2.2.3",
@@ -1550,7 +1596,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "num-integer",
  "num-traits",
 ]
@@ -1561,7 +1607,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
  "num-traits",
 ]
 
@@ -1571,7 +1617,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -1609,6 +1655,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "ordered-float"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,26 +1679,6 @@ dependencies = [
  "ff",
  "group",
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "parsec"
-version = "0.7.1"
-source = "git+https://github.com/maidsafe/parsec#32d925d3b3fe8f9e7b908474146a3399fbe584e3"
-dependencies = [
- "bincode",
- "failure",
- "fnv",
- "itertools 0.8.2",
- "lazy_static",
- "log 0.3.9",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "serde",
- "serde_derive",
- "threshold_crypto",
- "tiny-keccak 1.5.0",
- "unwrap",
 ]
 
 [[package]]
@@ -1713,7 +1745,7 @@ checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -1760,7 +1792,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
  "version_check",
 ]
 
@@ -1808,7 +1840,31 @@ dependencies = [
 [[package]]
 name = "quic-p2p"
 version = "0.7.0"
-source = "git+https://github.com/bochaco/quic-p2p.git?branch=fully-async#dd51569b824f4639e7c7d5f8d9080364f5651a80"
+source = "git+https://github.com/bochaco/quic-p2p.git?branch=fully-async#0aee96b289fbc39e23e4bed0ece290c84e7cdf96"
+dependencies = [
+ "base64 0.10.1",
+ "bincode",
+ "bytes 0.5.6",
+ "crossbeam-channel",
+ "directories 1.0.2",
+ "err-derive",
+ "futures",
+ "log",
+ "quinn",
+ "rcgen",
+ "rustls 0.17.0",
+ "serde",
+ "serde_json",
+ "structopt",
+ "tokio",
+ "unwrap",
+ "webpki",
+]
+
+[[package]]
+name = "quic-p2p"
+version = "0.7.0"
+source = "git+https://github.com/maidsafe/quic-p2p#c8bc722895860cea475a1709e361c57f33a52642"
 dependencies = [
  "base64 0.10.1",
  "bincode",
@@ -1818,7 +1874,7 @@ dependencies = [
  "err-derive",
  "futures",
  "igd",
- "log 0.4.11",
+ "log",
  "quinn",
  "rcgen",
  "rustls 0.17.0",
@@ -1845,7 +1901,7 @@ dependencies = [
  "err-derive",
  "futures",
  "igd",
- "log 0.4.11",
+ "log",
  "quinn",
  "rcgen",
  "rustls 0.17.0",
@@ -1879,7 +1935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
  "env_logger 0.7.1",
- "log 0.4.11",
+ "log",
  "rand 0.7.3",
  "rand_core 0.5.1",
 ]
@@ -2059,9 +2115,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_users"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom",
  "redox_syscall",
@@ -2097,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12427a5577082c24419c9c417db35cfeb65962efc7675bb6b0d5f1f9d315bfe6"
+checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
@@ -2113,7 +2169,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "mime",
  "mime_guess",
  "percent-encoding 2.1.0",
@@ -2150,27 +2206,27 @@ dependencies = [
 [[package]]
 name = "routing"
 version = "0.37.0"
-source = "git+https://github.com/bochaco/routing.git?branch=async-quic-p2p-api#27f0bdd5a5bcefe1c0220ef10aab8a83ae87ede7"
+source = "git+https://github.com/bochaco/routing.git?branch=async-quic-p2p-api#35ecfb266c7db5b9dc331d6915a42c8ee75a2e06"
 dependencies = [
  "bincode",
  "bls_dkg",
+ "bls_signature_aggregator",
  "bytes 0.5.6",
  "crossbeam-channel",
  "ed25519-dalek",
  "err-derive",
  "fake_clock",
+ "futures",
  "fxhash",
  "hex_fmt",
- "itertools 0.9.0",
- "log 0.4.11",
+ "itertools",
+ "log",
  "lru_time_cache",
- "parsec",
- "quic-p2p 0.7.0 (git+https://github.com/bochaco/quic-p2p.git?branch=fully-async)",
+ "quic-p2p 0.7.0 (git+https://github.com/maidsafe/quic-p2p)",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rand_os",
  "rand_xorshift",
- "safe-network-signature-aggregator",
  "serde",
  "threshold_crypto",
  "tiny-keccak 2.0.2",
@@ -2180,11 +2236,11 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.12.3",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -2203,7 +2259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
  "base64 0.11.0",
- "log 0.4.11",
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -2216,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
  "base64 0.12.3",
- "log 0.4.11",
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -2230,7 +2286,7 @@ checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -2241,8 +2297,8 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safe-nd"
-version = "0.11.3"
-source = "git+https://github.com/maidsafe/safe-nd.git#39ed587b76c3ef92c6827264d5c8592d66d8abcc"
+version = "0.11.4"
+source = "git+https://github.com/maidsafe/safe-nd.git#ce4359b9934bbeb4b128878b85c5aeff524d71ca"
 dependencies = [
  "bincode",
  "crdts",
@@ -2261,29 +2317,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "safe-network-signature-aggregator"
-version = "0.1.0"
-source = "git+https://github.com/maidsafe/safe-network-signature-aggregator#72f216fa4deeebb68a9ab4589c42f68172343d0c"
-dependencies = [
- "bincode",
- "err-derive",
- "fake_clock",
- "log 0.4.11",
- "rand 0.7.3",
- "serde",
- "threshold_crypto",
- "tiny-keccak 2.0.2",
-]
-
-[[package]]
 name = "safe-transfers"
 version = "0.1.0"
-source = "git+https://github.com/maidsafe/safe-transfers.git#5960b53ac23278552b9c30911021233c770895f3"
+source = "git+https://github.com/maidsafe/safe-transfers.git#b9f6ca2a0692d8cdd413db81648f1721ffaa6db5"
 dependencies = [
  "bincode",
  "crdts",
- "itertools 0.9.0",
- "log 0.4.11",
+ "itertools",
+ "log",
  "rand 0.7.3",
  "safe-nd",
  "serde",
@@ -2294,7 +2335,7 @@ dependencies = [
 [[package]]
 name = "safe_core"
 version = "0.42.1"
-source = "git+https://github.com/bochaco/safe_client_libs?branch=minor-changes-conn#397bcf4bb51b64e3632bcefee100adb131773a73"
+source = "git+https://github.com/bochaco/safe_client_libs?branch=minor-changes-conn#ac8cc72b5f163155f128e28eeebdaca2594688cd"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2310,12 +2351,12 @@ dependencies = [
  "futures-util",
  "hmac",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "log4rs",
  "lru",
  "miscreant",
  "pbkdf2",
- "quic-p2p 0.7.0 (git+https://github.com/bochaco/quic-p2p.git?branch=fully-async)",
+ "quic-p2p 0.7.0 (git+https://github.com/maidsafe/quic-p2p)",
  "rand 0.7.3",
  "regex",
  "safe-nd",
@@ -2347,7 +2388,6 @@ dependencies = [
  "directories 2.0.2",
  "ed25519",
  "ed25519-dalek",
- "fake_clock",
  "file-per-thread-logger",
  "flexi_logger",
  "futures",
@@ -2355,7 +2395,7 @@ dependencies = [
  "hex",
  "hex_fmt",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "maplit",
  "pickledb",
  "quic-p2p 0.7.0 (git+https://github.com/bochaco/quic-p2p.git?branch=fully-async)",
@@ -2369,8 +2409,9 @@ dependencies = [
  "self_update",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.8.2",
  "signature",
+ "sn_fake_clock",
  "structopt",
  "tempdir",
  "threshold_crypto",
@@ -2426,7 +2467,7 @@ dependencies = [
  "flate2",
  "hyper-old-types",
  "indicatif",
- "log 0.4.11",
+ "log",
  "quick-xml",
  "regex",
  "reqwest",
@@ -2489,7 +2530,7 @@ checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
 ]
 
 [[package]]
@@ -2533,10 +2574,10 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -2545,10 +2586,23 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2557,11 +2611,11 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.7.3",
  "byte-tools",
- "digest",
+ "digest 0.8.1",
  "keccak",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -2575,6 +2629,12 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "sn_fake_clock"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3bb89541a5068ba2861181892745587897765ea2724b78257eb5f289de16ab"
 
 [[package]]
 name = "socket2"
@@ -2600,7 +2660,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -2656,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
@@ -2673,15 +2733,15 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
  "unicode-xid 0.2.1",
 ]
 
 [[package]]
 name = "tar"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
+checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
 dependencies = [
  "filetime",
  "libc",
@@ -2781,7 +2841,7 @@ dependencies = [
  "ff",
  "group",
  "hex_fmt",
- "log 0.4.11",
+ "log",
  "pairing",
  "rand 0.7.3",
  "rand_chacha",
@@ -2792,11 +2852,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -2831,10 +2892,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35e75aa9554e28ec3553f2ed8f8ce534df06c5a998683f42091d2c883ab9022"
 dependencies = [
  "clear_on_drop",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.8.2",
 ]
 
 [[package]]
@@ -2864,14 +2925,14 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228139ddd4fea3fa345a29233009635235833e52807af7ea6448ead03890d6a9"
+checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls 0.18.1",
@@ -2888,7 +2949,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "log 0.4.11",
+ "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -2915,7 +2976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if",
- "log 0.4.11",
+ "log",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2928,14 +2989,14 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
+checksum = "4f0e00789804e99b20f12bc7003ca416309d28a6f495d6af58d1e2c2842461b5"
 dependencies = [
  "lazy_static",
 ]
@@ -3074,7 +3135,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.11",
+ "log",
  "try-lock",
 ]
 
@@ -3083,6 +3144,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3104,10 +3171,10 @@ checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.11",
+ "log",
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -3141,7 +3208,7 @@ checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3242,7 +3309,7 @@ dependencies = [
  "byteorder",
  "bytes 0.4.12",
  "httparse",
- "log 0.4.11",
+ "log",
  "mio",
  "mio-extras",
  "rand 0.7.3",
@@ -3291,7 +3358,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fa8a0b42a4cb692a96d21a3a028c759d763392f11ea4056504c9f6cb7e599c0"
 dependencies = [
- "log 0.4.11",
+ "log",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde",
@@ -3344,7 +3411,7 @@ checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
- "syn 1.0.38",
+ "syn 1.0.39",
  "synstructure",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bytes = { version = "~0.5.4", features = ["serde"] }
 crossbeam-channel = "~0.4.2"
 ctrlc = "3.1.3"
 directories = "2.0.1"
-fake_clock = "~0.3.0"
+sn_fake_clock = "~0.4.0"
 flexi_logger = "~0.14.8"
 fxhash = { version = "~0.2.1", optional = true }
 hex = "~0.3.2"

--- a/scripts/generate_dependency_graphs
+++ b/scripts/generate_dependency_graphs
@@ -7,5 +7,5 @@ mkdir images
 
 cargo install cargo-deps
 
-cargo deps --all-deps --include-orphans --filter safe_vault safe-nd parsec maidsafe_utilities routing mock-quic-p2p quic-p2p lru_time_cache fake_clock xor_name bls_dkg safe-network-signature-aggregator | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/safe_vault_maidsafe_dependencies.png
+cargo deps --all-deps --include-orphans --filter safe_vault safe-nd routing quic-p2p lru_time_cache sn_fake_clock xor_name bls_dkg bls_signature_aggregator safe-transfers | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/safe_vault_maidsafe_dependencies.png
 cargo deps | dot -T png -o images/safe_vault_all_dependencies.png


### PR DESCRIPTION
Also updates the dependency list in the dep graph generator script, removing mock-quick-p2p, parsec and maidsafe_utilities, and adding safe-transfers.

Note that there are several clippy errors, unrelated to my updates. These don't appear to be straight forward fixes that I can add in as part of this PR, maybe best for a vault dev to have a look.