### PR TITLE
Async chunk store file io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "rand_core 0.5.1",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "zeroize 1.1.0",
 ]
 
@@ -607,7 +607,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "zeroize 1.1.0",
 ]
 
@@ -1363,9 +1363,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1600,7 +1600,7 @@ dependencies = [
  "generic-array 0.12.3",
  "pmac",
  "stream-cipher",
- "subtle 2.2.3",
+ "subtle 2.3.0",
  "zeroize 0.5.2",
 ]
 
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "qp2p"
 version = "0.8.1"
-source = "git+https://github.com/maidsafe/qp2p#4f5d114afee01a7ec327816f7f1550e289f0219d"
+source = "git+https://github.com/maidsafe/qp2p#033f70f1e4af811385c241aa84fe8f554e38a4a9"
 dependencies = [
  "base64 0.12.3",
  "bincode",
@@ -2623,8 +2623,8 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "sn_data_types"
-version = "0.11.13"
-source = "git+https://github.com/maidsafe/sn_data_types.git#e702f92f3f9049681c81c0e650492af32e32d580"
+version = "0.11.16"
+source = "git+https://github.com/maidsafe/sn_data_types.git#bd9b0272da219ac6b2afc79848a99f5cd89b074f"
 dependencies = [
  "bincode",
  "crdts",
@@ -2751,9 +2751,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
@@ -3066,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0e00789804e99b20f12bc7003ca416309d28a6f495d6af58d1e2c2842461b5"
+checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
 dependencies = [
  "lazy_static",
 ]
@@ -3225,9 +3225,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
  "serde",
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3252,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f8d235a77f880bcef268d379810ea6c0af2eacfa90b1ad5af731776e0c4699"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3264,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
 dependencies = [
  "quote 1.0.7",
  "wasm-bindgen-macro-support",
@@ -3274,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.20",
  "quote 1.0.7",
@@ -3287,15 +3287,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.67"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "web-sys"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -654,7 +654,7 @@ version = "0.99.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -801,7 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "rustversion",
  "syn 1.0.40",
@@ -824,7 +824,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "synstructure",
@@ -862,7 +862,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -996,7 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1406,9 +1406,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "linked-hash-map"
@@ -1793,7 +1793,7 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -1834,7 +1834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "version_check",
@@ -1846,7 +1846,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "version_check",
 ]
@@ -1874,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
@@ -2009,7 +2009,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
 ]
 
 [[package]]
@@ -2316,7 +2316,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2330,7 +2330,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "safe_core"
 version = "0.42.1"
-source = "git+https://github.com/maidsafe/safe_client_libs#3f7ab9451f1bc6befff9e4b4b03e3953166d13d2"
+source = "git+https://github.com/maidsafe/safe_client_libs#061ebd7fa921fdb8dc9fa81241d08bc55744bf95"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2519,7 +2519,7 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2666,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2738,7 +2738,7 @@ checksum = "5e2513111825077552a6751dfad9e11ce0fba07d7276a3943a037d7e93e64c5f"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2772,7 +2772,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
 ]
@@ -2783,7 +2783,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "unicode-xid 0.2.1",
@@ -2877,7 +2877,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -2995,7 +2995,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -3059,7 +3059,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
 ]
@@ -3244,7 +3244,7 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "wasm-bindgen-shared",
@@ -3278,7 +3278,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "wasm-bindgen-backend",
@@ -3481,7 +3481,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.20",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
  "syn 1.0.40",
  "synstructure",
@@ -3489,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30de6e58104bb7b9a94f34b52a2bdabb8a40b678a64201cd0069e3d7119b5ff"
+checksum = "543adf038106b64cfca4711c82c917d785e3540e04f7996554488f988ec43124"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ sn_data_types = "~0.11.12"
 sn_transfers = "~0.2.0"
 ed25519 = "1.0.1"
 signature = "1.1.0"
-tokio = { version = "~0.2.5", features = ["macros", "fs"] }
+tokio = { version = "~0.2.5", features = ["macros", "fs", "stream"] }
 xor_name = "1.1.0"
 
 [dev_dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ sn_data_types = "~0.11.12"
 sn_transfers = "~0.2.0"
 ed25519 = "1.0.1"
 signature = "1.1.0"
-tokio = { version = "~0.2.5", features = ["macros"] }
+tokio = { version = "~0.2.5", features = ["macros", "fs"] }
 xor_name = "1.1.0"
 
 [dev_dependencies]

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -42,7 +42,7 @@ const VAULT_MODULE_NAME: &str = "safe_vault";
 /// Runs a SAFE Network vault.
 #[tokio::main]
 async fn main() {
-    let mut config = Config::new();
+    let mut config = Config::new().await;
 
     if let Some(c) = &config.completions() {
         match c.parse::<clap::Shell>() {
@@ -136,7 +136,7 @@ async fn main() {
             );
 
             if config.is_first() {
-                unwrap!(write_connection_info(&our_conn_info));
+                unwrap!(write_connection_info(&our_conn_info).await);
             }
         }
         Err(e) => {

--- a/src/chunk_store/mod.rs
+++ b/src/chunk_store/mod.rs
@@ -24,16 +24,16 @@ use error::{Error, Result};
 use log::trace;
 use sn_data_types::{Account, Blob, Map, Sequence};
 use std::{
-    cell::Cell,
     fs::Metadata,
     marker::PhantomData,
     path::{Path, PathBuf},
-    rc::Rc,
+    sync::Arc,
 };
 use tokio::{
     fs::{self, DirEntry, File},
     io::{AsyncReadExt, AsyncWriteExt},
     stream::StreamExt,
+    sync::RwLock,
 };
 use used_space::UsedSpace;
 
@@ -42,22 +42,20 @@ const CHUNK_STORE_DIR: &str = "chunks";
 /// The max name length for a chunk file.
 const MAX_CHUNK_FILE_NAME_LENGTH: usize = 104;
 
-pub(crate) type BlobChunkStore = ChunkStore<Blob>;
-pub(crate) type MapChunkStore = ChunkStore<Map>;
-pub(crate) type SequenceChunkStore = ChunkStore<Sequence>;
-pub(crate) type AccountChunkStore = ChunkStore<Account>;
+pub(crate) type BlobChunkStoreApi = ChunkStoreApi<Blob>;
+pub(crate) type MapChunkStoreApi = ChunkStoreApi<Map>;
+pub(crate) type SequenceChunkStoreApi = ChunkStoreApi<Sequence>;
+pub(crate) type AccountChunkStoreApi = ChunkStoreApi<Account>;
+
 
 /// `ChunkStore` is a store of data held as serialised files on disk, implementing a maximum disk
 /// usage to restrict storage.
-pub(crate) struct ChunkStore<T: Chunk> {
-    dir: PathBuf,
-    // Maximum space allowed for all `ChunkStore`s to consume.
-    max_capacity: u64,
-    used_space: UsedSpace,
-    _phantom: PhantomData<T>,
+pub(crate) struct ChunkStoreApi<T: Chunk> {
+    inner: Arc<RwLock<ChunkStore<T>>>,
+    total_used: Arc<RwLock<u64>>,
 }
 
-impl<T> ChunkStore<T>
+impl<T> ChunkStoreApi<T>
 where
     T: Chunk,
     Self: Subdir,
@@ -70,9 +68,9 @@ where
     /// The maximum storage space is defined by `max_capacity`.  This specifies the max usable by
     /// _all_ `ChunkStores`, not per `ChunkStore`.
     pub async fn new<P: AsRef<Path>>(
+        total_used: Arc<RwLock<u64>>,
         root: P,
         max_capacity: u64,
-        total_used_space: Rc<Cell<u64>>,
         init_mode: Init,
     ) -> Result<Self> {
         let dir = root.as_ref().join(CHUNK_STORE_DIR).join(Self::subdir());
@@ -82,17 +80,21 @@ where
             Init::Load => trace!("Loading ChunkStore at {}", dir.display()),
         }
 
-        let used_space = UsedSpace::new(&dir, total_used_space, init_mode).await?;
-        Ok(ChunkStore {
+        let used_space = UsedSpace::new(&dir, init_mode).await?;
+        let inner = ChunkStore {
             dir,
             max_capacity,
             used_space,
             _phantom: PhantomData,
+        };
+        Ok( Self{
+            inner: Arc::new(RwLock::new(inner)),
+            total_used: total_used,
         })
     }
 }
 
-impl<T: Chunk> ChunkStore<T> {
+impl<T: Chunk> ChunkStoreApi<T> {
     async fn create_new_root(root: &Path) -> Result<()> {
         trace!("Creating ChunkStore at {}", root.display());
         fs::create_dir_all(root).await?;
@@ -112,20 +114,51 @@ impl<T: Chunk> ChunkStore<T> {
     ///
     /// If a chunk with the same id already exists, it will be overwritten.
     pub async fn put(&mut self, chunk: &T) -> Result<()> {
+
         let serialised_chunk = utils::serialise(chunk);
         let consumed_space = serialised_chunk.len() as u64;
-        if self.used_space.total().saturating_add(consumed_space) > self.max_capacity {
-            return Err(Error::NotEnoughSpace);
+
+        // reserve the space first and back it out if needed later
+        {
+            let max_capacity = self.inner.read().await.max_capacity;
+            let mut total = self.total_used.write().await;
+            let new_total = total.saturating_add(consumed_space);
+            if new_total > max_capacity {
+                return Err(Error::NotEnoughSpace);
+            }
+            *total = new_total;
         }
 
-        let file_path = self.file_path(chunk.id())?;
-        let _ = self.do_delete(&file_path);
+        // allow ourselves to back out on failure
+        let total_used_clone = self.total_used.clone();
+        let back_out = || async move {
+            let mut total = total_used_clone.write().await;
+            *total = *total - consumed_space;
+        };
 
-        let mut file = File::create(&file_path).await?;
-        file.write_all(&serialised_chunk).await?;
-        file.sync_data().await?;
+        // run the function in one block
+        let total_used_clone_two = self.total_used.clone();
+        let try_write = async move {
 
-        self.used_space.increase(consumed_space).await
+            let file_path = Self::file_path(self.inner.clone(), chunk.id()).await?;
+            let _ = Self::do_delete(self.inner.clone(), &file_path).await?;
+
+            let mut file = File::create(&file_path).await?;
+            file.write_all(&serialised_chunk).await?;
+            file.sync_data().await?;
+
+            let res : Result<()> = Ok(()); //need return type explicit
+            res
+        };
+
+        // finally await
+        match tokio::try_join!( try_write ) {
+            Ok(_) => Ok(()),
+            Err(e) => { 
+                back_out();
+                Err(e)
+            },
+        }
     }
 
     /// Deletes the data chunk stored under `id`.
@@ -133,14 +166,39 @@ impl<T: Chunk> ChunkStore<T> {
     /// If the data doesn't exist, it does nothing and returns `Ok`.  In the case of an IO error, it
     /// returns `Error::Io`.
     pub async fn delete(&mut self, id: &T::Id) -> Result<()> {
-        self.do_delete(&self.file_path(id)?).await
+        let file_path = Self::file_path(self.inner.clone(), id).await?;
+        Self::do_delete(self.inner.clone(), &file_path).await
     }
 
+
+    async fn do_delete(inner: Arc<RwLock<ChunkStore<T>>>, file_path: &Path) -> Result<()> {
+        if let Ok(metadata) = fs::metadata(file_path).await {
+            {
+                inner.write().await.used_space.decrease(metadata.len());
+                fs::remove_file(file_path).await.map_err(From::from)
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn get(&self, id: &T::Id) -> Result<T> {
+        Self::__get(self.inner.clone(), &id).await
+    }
+
+    pub async fn has(&self, id: &T::Id) -> bool {
+        Self::__has(self.inner.clone(), &id).await
+    }
+
+    pub async fn keys(&self) -> Vec<T::Id> {
+        Self::__keys(self.inner.clone()).await
+    }
+    
     /// Returns a data chunk previously stored under `id`.
     ///
     /// If the data file can't be accessed, it returns `Error::NoSuchChunk`.
-    pub async fn get(&self, id: &T::Id) -> Result<T> {
-        let mut file = File::open(self.file_path(id)?)
+    async fn __get(cs: Arc<RwLock<ChunkStore<T>>>, id: &T::Id) -> Result<T> {
+        let mut file = File::open(Self::file_path(cs.clone(), id).await?)
             .await
             .map_err(|_| Error::NoSuchChunk)?;
         let mut contents = vec![];
@@ -155,8 +213,8 @@ impl<T: Chunk> ChunkStore<T> {
     }
 
     /// Tests if a data chunk has been previously stored under `id`.
-    pub async fn has(&self, id: &T::Id) -> bool {
-        if let Ok(path) = self.file_path(id) {
+    async fn __has(cs: Arc<RwLock<ChunkStore<T>>>, id: &T::Id) -> bool {
+        if let Ok(path) = Self::file_path(cs.clone(), id).await {
             fs::metadata(path)
                 .await
                 .as_ref()
@@ -169,8 +227,9 @@ impl<T: Chunk> ChunkStore<T> {
 
     /// Lists all keys of currently stored data.
     #[cfg_attr(not(test), allow(unused))]
-    pub async fn keys(&self) -> Vec<T::Id> {
-        match fs::read_dir(&self.dir).await {
+    async fn __keys(cs: Arc<RwLock<ChunkStore<T>>>) -> Vec<T::Id> {
+        let cs_rlock = cs.read().await;
+        match fs::read_dir(&cs_rlock.dir).await {
             Ok(entries) => {
                 entries
                     .filter_map(|entry| to_chunk_id(&entry.ok()?))
@@ -181,17 +240,9 @@ impl<T: Chunk> ChunkStore<T> {
         }
     }
 
-    async fn do_delete(&mut self, file_path: &Path) -> Result<()> {
-        if let Ok(metadata) = fs::metadata(file_path).await {
-            self.used_space.decrease(metadata.len()).await?;
-            fs::remove_file(file_path).await.map_err(From::from)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn file_path(&self, id: &T::Id) -> Result<PathBuf> {
-        Ok(self.dir.join(&hex::encode(utils::serialise(id))))
+    async fn file_path(cs: Arc<RwLock<ChunkStore<T>>>, id: &T::Id) -> Result<PathBuf> {
+        let cs_rlock = cs.read().await;
+        Ok(cs_rlock.dir.join(&hex::encode(utils::serialise(id))))
     }
 }
 
@@ -199,25 +250,25 @@ pub(crate) trait Subdir {
     fn subdir() -> &'static Path;
 }
 
-impl Subdir for BlobChunkStore {
+impl Subdir for BlobChunkStoreApi {
     fn subdir() -> &'static Path {
         Path::new("immutable")
     }
 }
 
-impl Subdir for MapChunkStore {
+impl Subdir for MapChunkStoreApi {
     fn subdir() -> &'static Path {
         Path::new("mutable")
     }
 }
 
-impl Subdir for SequenceChunkStore {
+impl Subdir for SequenceChunkStoreApi {
     fn subdir() -> &'static Path {
         Path::new("sequence")
     }
 }
 
-impl Subdir for AccountChunkStore {
+impl Subdir for AccountChunkStoreApi {
     fn subdir() -> &'static Path {
         Path::new("login_packets")
     }
@@ -228,4 +279,13 @@ fn to_chunk_id<T: ChunkId>(entry: &DirEntry) -> Option<T> {
     let file_name = file_name.into_string().ok()?;
     let bytes = hex::decode(file_name).ok()?;
     bincode::deserialize(&bytes).ok()
+}
+
+struct ChunkStore<T:Chunk> {
+    pub dir: PathBuf,
+    // Maximum space allowed for all `ChunkStore`s to consume.
+    pub max_capacity: u64,
+    // local used space in this chunk store
+    pub used_space: UsedSpace,
+    pub _phantom: PhantomData<T>,
 }

--- a/src/chunk_store/used_space.rs
+++ b/src/chunk_store/used_space.rs
@@ -8,15 +8,10 @@
 
 use super::error::{Error, Result};
 use crate::node::state_db::Init;
-use std::{
-    cell::Cell,
-    io::SeekFrom,
-    path::Path,
-    rc::Rc,
-};
+use std::{cell::Cell, io::SeekFrom, path::Path, rc::Rc};
 use tokio::{
     fs::{File, OpenOptions},
-    io::{ AsyncReadExt, AsyncWriteExt},
+    io::{AsyncReadExt, AsyncWriteExt},
 };
 
 const USED_SPACE_FILENAME: &str = "used_space";
@@ -43,7 +38,8 @@ impl UsedSpace {
             .read(true)
             .write(true)
             .create(true)
-            .open(dir.as_ref().join(USED_SPACE_FILENAME)).await?;
+            .open(dir.as_ref().join(USED_SPACE_FILENAME))
+            .await?;
         let local_value = if init_mode == Init::Load {
             let mut buffer = vec![];
             let _ = local_record.read_to_end(&mut buffer).await?;
@@ -87,7 +83,6 @@ impl UsedSpace {
     }
 
     async fn record_new_values(&mut self, total: u64, local: u64) -> Result<()> {
-
         self.local_record.set_len(0).await?;
         let _ = self.local_record.seek(SeekFrom::Start(0)).await?;
 

--- a/src/node/adult_duties/chunks/chunk_storage.rs
+++ b/src/node/adult_duties/chunks/chunk_storage.rs
@@ -26,13 +26,17 @@ pub(crate) struct ChunkStorage {
 }
 
 impl ChunkStorage {
-    pub(crate) async fn new(node_info: &NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
+    pub(crate) async fn new(
+        node_info: &NodeInfo,
+        total_used_space: &Rc<Cell<u64>>,
+    ) -> Result<Self> {
         let chunks = BlobChunkStore::new(
             node_info.path(),
             node_info.max_storage_capacity,
             Rc::clone(total_used_space),
             node_info.init_mode,
-        ).await?;
+        )
+        .await?;
         let wrapping = AdultMsgWrapping::new(node_info.keys(), AdultDuties::ChunkStorage);
         Ok(Self { chunks, wrapping })
     }
@@ -91,7 +95,8 @@ impl ChunkStorage {
             return Err(NdError::DataExists);
         }
         self.chunks
-            .put(&data).await
+            .put(&data)
+            .await
             .map_err(|error| error.to_string().into())
     }
 
@@ -103,7 +108,8 @@ impl ChunkStorage {
     ) -> Option<MessagingDuty> {
         let result = self
             .chunks
-            .get(address).await
+            .get(address)
+            .await
             .map_err(|error| error.to_string().into());
         self.wrapping.send(Message::QueryResponse {
             id: MessageId::new(),
@@ -150,7 +156,8 @@ impl ChunkStorage {
         let result = match self.chunks.get(&address).await {
             Ok(Blob::Private(_)) => self
                 .chunks
-                .delete(&address).await
+                .delete(&address)
+                .await
                 .map_err(|error| error.to_string().into()),
             Ok(_) => {
                 error!(

--- a/src/node/adult_duties/chunks/mod.rs
+++ b/src/node/adult_duties/chunks/mod.rs
@@ -28,13 +28,13 @@ pub(crate) struct Chunks {
 }
 
 impl Chunks {
-    pub fn new(node_info: &NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
-        let chunk_storage = ChunkStorage::new(node_info, total_used_space)?;
+    pub async fn new(node_info: &NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
+        let chunk_storage = ChunkStorage::new(node_info, total_used_space).await?;
 
         Ok(Self { chunk_storage })
     }
 
-    pub fn receive_msg(&mut self, msg: &MsgEnvelope) -> Option<MessagingDuty> {
+    pub async fn receive_msg(&mut self, msg: &MsgEnvelope) -> Option<MessagingDuty> {
         trace!(
             "{}: Received ({:?} from src {:?}",
             self,
@@ -45,7 +45,7 @@ impl Chunks {
             Message::Query {
                 query: Query::Data(DataQuery::Blob(read)),
                 ..
-            } => reading::get_result(read, msg, &self.chunk_storage),
+            } => reading::get_result(read, msg, &self.chunk_storage).await,
             Message::Cmd {
                 cmd:
                     Cmd::Data {
@@ -53,7 +53,7 @@ impl Chunks {
                         ..
                     },
                 ..
-            } => writing::get_result(write, msg, &mut self.chunk_storage),
+            } => writing::get_result(write, msg, &mut self.chunk_storage).await,
             _ => None,
         }
     }

--- a/src/node/adult_duties/chunks/reading.rs
+++ b/src/node/adult_duties/chunks/reading.rs
@@ -13,7 +13,7 @@ use sn_data_types::{Address, BlobRead, MsgEnvelope};
 
 /// Read operations on data chunks.
 
-pub(super) fn get_result(
+pub(super) async fn get_result(
     read: &BlobRead,
     msg: &MsgEnvelope,
     storage: &ChunkStorage,
@@ -21,7 +21,7 @@ pub(super) fn get_result(
     let BlobRead::Get(address) = read;
     if let Address::Section(_) = msg.most_recent_sender().address() {
         if msg.verify() {
-            storage.get(address, msg.id(), &msg.origin)
+            storage.get(address, msg.id(), &msg.origin).await
         } else {
             error!("Accumulated signature is invalid!");
             None

--- a/src/node/adult_duties/chunks/writing.rs
+++ b/src/node/adult_duties/chunks/writing.rs
@@ -13,7 +13,7 @@ use crate::node::node_ops::MessagingDuty;
 use log::error;
 use sn_data_types::{BlobWrite, MsgEnvelope};
 
-pub(super) fn get_result(
+pub(super) async fn get_result(
     write: &BlobWrite,
     msg: &MsgEnvelope,
     storage: &mut ChunkStorage,
@@ -22,7 +22,7 @@ pub(super) fn get_result(
     match &write {
         New(data) => {
             if msg.verify() {
-                storage.store(&data, msg.id(), &msg.origin)
+                storage.store(&data, msg.id(), &msg.origin).await
             } else {
                 error!("Accumulated signature for {:?} is invalid!", &msg.id());
                 None
@@ -31,7 +31,7 @@ pub(super) fn get_result(
         DeletePrivate(address) => {
             if msg.verify() {
                 // really though, for a delete, what we should be looking at is the origin signature! That would be the source of truth!
-                storage.delete(*address, msg.id(), &msg.origin)
+                storage.delete(*address, msg.id(), &msg.origin).await
             } else {
                 error!("Accumulated signature is invalid!");
                 None

--- a/src/node/adult_duties/mod.rs
+++ b/src/node/adult_duties/mod.rs
@@ -27,17 +27,17 @@ pub struct AdultDuties {
 }
 
 impl AdultDuties {
-    pub fn new(node_info: &NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
-        let chunks = Chunks::new(node_info, &total_used_space)?;
+    pub async fn new(node_info: &NodeInfo, total_used_space: &Rc<Cell<u64>>) -> Result<Self> {
+        let chunks = Chunks::new(node_info, &total_used_space).await?;
         Ok(Self { chunks })
     }
 
-    pub fn process(&mut self, duty: &AdultDuty) -> Option<NodeOperation> {
+    pub async fn process(&mut self, duty: &AdultDuty) -> Option<NodeOperation> {
         use AdultDuty::*;
         use ChunkDuty::*;
         let RunAsChunks(chunk_duty) = duty;
         let result = match chunk_duty {
-            ReadChunk(msg) | WriteChunk(msg) => self.chunks.receive_msg(msg),
+            ReadChunk(msg) | WriteChunk(msg) => self.chunks.receive_msg(msg).await,
         };
 
         result.map(|c| c.into())

--- a/src/node/elder_duties/data_section/metadata/account_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/account_storage.rs
@@ -44,7 +44,8 @@ impl AccountStorage {
             node_info.max_storage_capacity,
             Rc::clone(total_used_space),
             node_info.init_mode,
-        ).await?;
+        )
+        .await?;
         Ok(Self { chunks, wrapping })
     }
 
@@ -67,7 +68,8 @@ impl AccountStorage {
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
         let result = self
-            .account(&origin.id(), address).await
+            .account(&origin.id(), address)
+            .await
             .map(Account::into_data_and_signature);
         self.wrapping.send(Message::QueryResponse {
             id: MessageId::new(),
@@ -102,8 +104,9 @@ impl AccountStorage {
             Err(NdError::InvalidOwners)
         } else {
             // also check the signature
-            self
-                .chunks.put(account).await
+            self.chunks
+                .put(account)
+                .await
                 .map_err(|error| error.to_string().into())
         };
         self.ok_or_error(result, msg_id, &origin)
@@ -115,10 +118,9 @@ impl AccountStorage {
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
-        
-        let result = 
-            self.account(&origin.id(), updated_account.address()).await
-            .map_err(|e| NdError::from(e));
+        let result = self
+            .account(&origin.id(), updated_account.address())
+            .await;
 
         if let Ok(existing_account) = result {
             let result_inner;
@@ -129,7 +131,9 @@ impl AccountStorage {
             } else {
                 // also check the signature
                 result_inner = self
-                    .chunks.put(&updated_account).await
+                    .chunks
+                    .put(&updated_account)
+                    .await
                     .map_err(|e| e.to_string().into())
             }
             self.ok_or_error(result_inner, msg_id, &origin)
@@ -140,7 +144,8 @@ impl AccountStorage {
 
     async fn account(&self, requester_pub_key: &PublicKey, address: &XorName) -> NdResult<Account> {
         self.chunks
-            .get(address).await
+            .get(address)
+            .await
             .map_err(|e| match e {
                 ChunkStoreError::NoSuchChunk => NdError::NoSuchLoginPacket,
                 error => error.to_string().into(),

--- a/src/node/elder_duties/data_section/metadata/account_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/account_storage.rs
@@ -118,9 +118,7 @@ impl AccountStorage {
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
-        let result = self
-            .account(&origin.id(), updated_account.address())
-            .await;
+        let result = self.account(&origin.id(), updated_account.address()).await;
 
         if let Ok(existing_account) = result {
             let result_inner;

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -61,8 +61,10 @@ impl BlobRegister {
         wrapping: ElderMsgWrapping,
         routing: Network,
     ) -> Result<Self> {
-        let metadata = utils::new_db(node_info.path(), BLOB_META_DB_NAME, node_info.init_mode).await?;
-        let holders = utils::new_db(node_info.path(), HOLDER_META_DB_NAME, node_info.init_mode).await?;
+        let metadata =
+            utils::new_db(node_info.path(), BLOB_META_DB_NAME, node_info.init_mode).await?;
+        let holders =
+            utils::new_db(node_info.path(), HOLDER_META_DB_NAME, node_info.init_mode).await?;
         let full_adults =
             utils::new_db(node_info.path(), FULL_ADULTS_DB_NAME, node_info.init_mode).await?;
 

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -56,15 +56,15 @@ pub(super) struct BlobRegister {
 }
 
 impl BlobRegister {
-    pub(super) fn new(
+    pub(super) async fn new(
         node_info: &NodeInfo,
         wrapping: ElderMsgWrapping,
         routing: Network,
     ) -> Result<Self> {
-        let metadata = utils::new_db(node_info.path(), BLOB_META_DB_NAME, node_info.init_mode)?;
-        let holders = utils::new_db(node_info.path(), HOLDER_META_DB_NAME, node_info.init_mode)?;
+        let metadata = utils::new_db(node_info.path(), BLOB_META_DB_NAME, node_info.init_mode).await?;
+        let holders = utils::new_db(node_info.path(), HOLDER_META_DB_NAME, node_info.init_mode).await?;
         let full_adults =
-            utils::new_db(node_info.path(), FULL_ADULTS_DB_NAME, node_info.init_mode)?;
+            utils::new_db(node_info.path(), FULL_ADULTS_DB_NAME, node_info.init_mode).await?;
 
         Ok(Self {
             metadata,

--- a/src/node/elder_duties/data_section/metadata/map_storage.rs
+++ b/src/node/elder_duties/data_section/metadata/map_storage.rs
@@ -31,7 +31,7 @@ pub(super) struct MapStorage {
 }
 
 impl MapStorage {
-    pub(super) fn new(
+    pub(super) async fn new(
         node_info: &NodeInfo,
         total_used_space: &Rc<Cell<u64>>,
         wrapping: ElderMsgWrapping,
@@ -41,11 +41,11 @@ impl MapStorage {
             node_info.max_storage_capacity,
             Rc::clone(total_used_space),
             node_info.init_mode,
-        )?;
+        ).await?;
         Ok(Self { chunks, wrapping })
     }
 
-    pub(super) fn read(
+    pub(super) async fn read(
         &self,
         read: &MapRead,
         msg_id: MessageId,
@@ -53,21 +53,21 @@ impl MapStorage {
     ) -> Option<MessagingDuty> {
         use MapRead::*;
         match read {
-            Get(address) => self.get(*address, msg_id, origin),
-            GetValue { address, ref key } => self.get_value(*address, key, msg_id, origin),
-            GetShell(address) => self.get_shell(*address, msg_id, origin),
-            GetVersion(address) => self.get_version(*address, msg_id, origin),
-            ListEntries(address) => self.list_entries(*address, msg_id, origin),
-            ListKeys(address) => self.list_keys(*address, msg_id, origin),
-            ListValues(address) => self.list_values(*address, msg_id, origin),
-            ListPermissions(address) => self.list_permissions(*address, msg_id, origin),
+            Get(address) => self.get(*address, msg_id, origin).await,
+            GetValue { address, ref key } => self.get_value(*address, key, msg_id, origin).await,
+            GetShell(address) => self.get_shell(*address, msg_id, origin).await,
+            GetVersion(address) => self.get_version(*address, msg_id, origin).await,
+            ListEntries(address) => self.list_entries(*address, msg_id, origin).await,
+            ListKeys(address) => self.list_keys(*address, msg_id, origin).await,
+            ListValues(address) => self.list_values(*address, msg_id, origin).await,
+            ListPermissions(address) => self.list_permissions(*address, msg_id, origin).await,
             ListUserPermissions { address, user } => {
-                self.list_user_permissions(*address, *user, msg_id, origin)
+                self.list_user_permissions(*address, *user, msg_id, origin).await
             }
         }
     }
 
-    pub(super) fn write(
+    pub(super) async fn write(
         &mut self,
         write: MapWrite,
         msg_id: MessageId,
@@ -75,20 +75,20 @@ impl MapStorage {
     ) -> Option<MessagingDuty> {
         use MapWrite::*;
         match write {
-            New(data) => self.create(&data, msg_id, origin),
-            Delete(address) => self.delete(address, msg_id, origin),
+            New(data) => self.create(&data, msg_id, origin).await,
+            Delete(address) => self.delete(address, msg_id, origin).await,
             SetUserPermissions {
                 address,
                 user,
                 ref permissions,
                 version,
-            } => self.set_user_permissions(address, user, permissions, version, msg_id, origin),
+            } => self.set_user_permissions(address, user, permissions, version, msg_id, origin).await,
             DelUserPermissions {
                 address,
                 user,
                 version,
-            } => self.delete_user_permissions(address, user, version, msg_id, origin),
-            Edit { address, changes } => self.edit_entries(address, changes, msg_id, origin),
+            } => self.delete_user_permissions(address, user, version, msg_id, origin).await,
+            Edit { address, changes } => self.edit_entries(address, changes, msg_id, origin).await,
         }
     }
 
@@ -96,7 +96,7 @@ impl MapStorage {
     /// Returns `Some(Result<..>)` if the flow should be continued, returns
     /// `None` if there was a logic error encountered and the flow should be
     /// terminated.
-    fn get_chunk(
+    async fn get_chunk(
         &self,
         address: &MapAddress,
         origin: &MsgSender,
@@ -104,7 +104,7 @@ impl MapStorage {
     ) -> Option<NdResult<Map>> {
         Some(
             self.chunks
-                .get(&address)
+                .get(&address).await
                 .map_err(|e| match e {
                     ChunkStoreError::NoSuchChunk => NdError::NoSuchData,
                     error => error.to_string().into(),
@@ -114,7 +114,7 @@ impl MapStorage {
     }
 
     /// Get Map from the chunk store, update it, and overwrite the stored chunk.
-    fn edit_chunk<F>(
+    async fn edit_chunk<F>(
         &mut self,
         address: &MapAddress,
         origin: &MsgSender,
@@ -126,38 +126,42 @@ impl MapStorage {
     {
         let result = self
             .chunks
-            .get(address)
+            .get(address).await
             .map_err(|e| match e {
                 ChunkStoreError::NoSuchChunk => NdError::NoSuchData,
                 error => error.to_string().into(),
             })
-            .and_then(mutation_fn)
-            .and_then(|map| {
-                self.chunks
-                    .put(&map)
-                    .map_err(|error| error.to_string().into())
-            });
-        self.ok_or_error(result, msg_id, &origin)
+            .and_then(mutation_fn);
+        
+        if let Ok(ref map) = result {
+            let result_inner = self.chunks
+                .put(&map).await
+                .map_err(|error| error.to_string().into());
+            self.ok_or_error(result_inner, msg_id, &origin)
+        }
+        else {
+            self.ok_or_error(result.map(|_| ()), msg_id, &origin)
+        }
     }
 
     /// Put Map.
-    fn create(
+    async fn create(
         &mut self,
         data: &Map,
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
-        let result = if self.chunks.has(data.address()) {
+        let result = if self.chunks.has(data.address()).await {
             Err(NdError::DataExists)
         } else {
             self.chunks
-                .put(&data)
+                .put(&data).await
                 .map_err(|error| error.to_string().into())
         };
         self.ok_or_error(result, msg_id, origin)
     }
 
-    fn delete(
+    async fn delete(
         &mut self,
         address: MapAddress,
         msg_id: MessageId,
@@ -165,23 +169,27 @@ impl MapStorage {
     ) -> Option<MessagingDuty> {
         let result = self
             .chunks
-            .get(&address)
+            .get(&address).await
             .map_err(|e| match e {
                 ChunkStoreError::NoSuchChunk => NdError::NoSuchData,
                 error => error.to_string().into(),
             })
-            .and_then(|map| {
-                map.check_is_owner(origin.id())?;
-                self.chunks
-                    .delete(&address)
-                    .map_err(|error| error.to_string().into())
-            });
+            .and_then(|map| map.check_is_owner(origin.id()));
 
-        self.ok_or_error(result, msg_id, origin)
+        if let Ok(_) = result {
+            let result_inner = self
+                .chunks
+                .delete(&address).await
+                .map_err(|error| error.to_string().into());
+            self.ok_or_error(result_inner, msg_id, origin)
+        }
+        else {
+            self.ok_or_error(result, msg_id, origin)
+        }
     }
 
     /// Set Map user permissions.
-    fn set_user_permissions(
+    async fn set_user_permissions(
         &mut self,
         address: MapAddress,
         user: PublicKey,
@@ -194,11 +202,11 @@ impl MapStorage {
             data.check_permissions(MapAction::ManagePermissions, origin.id())?;
             data.set_user_permissions(user, permissions.clone(), version)?;
             Ok(data)
-        })
+        }).await
     }
 
     /// Delete Map user permissions.
-    fn delete_user_permissions(
+    async fn delete_user_permissions(
         &mut self,
         address: MapAddress,
         user: PublicKey,
@@ -210,11 +218,11 @@ impl MapStorage {
             data.check_permissions(MapAction::ManagePermissions, origin.id())?;
             data.del_user_permissions(user, version)?;
             Ok(data)
-        })
+        }).await
     }
 
     /// Edit Map.
-    fn edit_entries(
+    async fn edit_entries(
         &mut self,
         address: MapAddress,
         actions: MapEntryActions,
@@ -224,17 +232,17 @@ impl MapStorage {
         self.edit_chunk(&address, origin, msg_id, move |mut data| {
             data.mutate_entries(actions, origin.id())?;
             Ok(data)
-        })
+        }).await
     }
 
     /// Get entire Map.
-    fn get(
+    async fn get(
         &self,
         address: MapAddress,
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
-        let result = self.get_chunk(&address, origin, MapAction::Read)?;
+        let result = self.get_chunk(&address, origin, MapAction::Read).await?;
         self.wrapping.send(Message::QueryResponse {
             response: QueryResponse::GetMap(result),
             id: MessageId::new(),
@@ -244,14 +252,14 @@ impl MapStorage {
     }
 
     /// Get Map shell.
-    fn get_shell(
+    async fn get_shell(
         &self,
         address: MapAddress,
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
         let result = self
-            .get_chunk(&address, origin, MapAction::Read)?
+            .get_chunk(&address, origin, MapAction::Read).await?
             .map(|data| data.shell());
         self.wrapping.send(Message::QueryResponse {
             response: QueryResponse::GetMapShell(result),
@@ -262,14 +270,14 @@ impl MapStorage {
     }
 
     /// Get Map version.
-    fn get_version(
+    async fn get_version(
         &self,
         address: MapAddress,
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
         let result = self
-            .get_chunk(&address, origin, MapAction::Read)?
+            .get_chunk(&address, origin, MapAction::Read).await?
             .map(|data| data.version());
         self.wrapping.send(Message::QueryResponse {
             response: QueryResponse::GetMapVersion(result),
@@ -280,14 +288,14 @@ impl MapStorage {
     }
 
     /// Get Map value.
-    fn get_value(
+    async fn get_value(
         &self,
         address: MapAddress,
         key: &[u8],
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
-        let res = self.get_chunk(&address, origin, MapAction::Read)?;
+        let res = self.get_chunk(&address, origin, MapAction::Read).await?;
         let result = res.and_then(|data| match data {
             Map::Seq(map) => map
                 .get(key)
@@ -309,14 +317,14 @@ impl MapStorage {
     }
 
     /// Get Map keys.
-    fn list_keys(
+    async fn list_keys(
         &self,
         address: MapAddress,
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
         let result = self
-            .get_chunk(&address, origin, MapAction::Read)?
+            .get_chunk(&address, origin, MapAction::Read).await?
             .map(|data| data.keys());
         self.wrapping.send(Message::QueryResponse {
             response: QueryResponse::ListMapKeys(result),
@@ -327,13 +335,13 @@ impl MapStorage {
     }
 
     /// Get Map values.
-    fn list_values(
+    async fn list_values(
         &self,
         address: MapAddress,
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
-        let res = self.get_chunk(&address, origin, MapAction::Read)?;
+        let res = self.get_chunk(&address, origin, MapAction::Read).await?;
         let result = res.map(|data| match data {
             Map::Seq(map) => map.values().into(),
             Map::Unseq(map) => map.values().into(),
@@ -347,13 +355,13 @@ impl MapStorage {
     }
 
     /// Get Map entries.
-    fn list_entries(
+    async fn list_entries(
         &self,
         address: MapAddress,
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
-        let res = self.get_chunk(&address, origin, MapAction::Read)?;
+        let res = self.get_chunk(&address, origin, MapAction::Read).await?;
         let result = res.map(|data| match data {
             Map::Seq(map) => map.entries().clone().into(),
             Map::Unseq(map) => map.entries().clone().into(),
@@ -367,14 +375,14 @@ impl MapStorage {
     }
 
     /// Get Map permissions.
-    fn list_permissions(
+    async fn list_permissions(
         &self,
         address: MapAddress,
         msg_id: MessageId,
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
         let result = self
-            .get_chunk(&address, origin, MapAction::Read)?
+            .get_chunk(&address, origin, MapAction::Read).await?
             .map(|data| data.permissions());
         self.wrapping.send(Message::QueryResponse {
             response: QueryResponse::ListMapPermissions(result),
@@ -385,7 +393,7 @@ impl MapStorage {
     }
 
     /// Get Map user permissions.
-    fn list_user_permissions(
+    async fn list_user_permissions(
         &self,
         address: MapAddress,
         user: PublicKey,
@@ -393,7 +401,7 @@ impl MapStorage {
         origin: &MsgSender,
     ) -> Option<MessagingDuty> {
         let result = self
-            .get_chunk(&address, origin, MapAction::Read)?
+            .get_chunk(&address, origin, MapAction::Read).await?
             .and_then(|data| data.user_permissions(user).map(MapPermissionSet::clone));
         self.wrapping.send(Message::QueryResponse {
             response: QueryResponse::ListMapUserPermissions(result),

--- a/src/node/elder_duties/data_section/metadata/mod.rs
+++ b/src/node/elder_duties/data_section/metadata/mod.rs
@@ -52,10 +52,12 @@ impl Metadata {
         routing: Network,
     ) -> Result<Self> {
         let wrapping = ElderMsgWrapping::new(node_info.keys(), ElderDuties::Metadata);
-        let account_storage = AccountStorage::new(node_info, total_used_space, wrapping.clone()).await?;
+        let account_storage =
+            AccountStorage::new(node_info, total_used_space, wrapping.clone()).await?;
         let blob_register = BlobRegister::new(node_info, wrapping.clone(), routing).await?;
         let map_storage = MapStorage::new(node_info, total_used_space, wrapping.clone()).await?;
-        let sequence_storage = SequenceStorage::new(node_info, total_used_space, wrapping.clone()).await?;
+        let sequence_storage =
+            SequenceStorage::new(node_info, total_used_space, wrapping.clone()).await?;
         let elder_stores = ElderStores::new(
             account_storage,
             blob_register,
@@ -78,7 +80,9 @@ impl Metadata {
     async fn process_msg(&mut self, msg: MsgEnvelope) -> Option<NodeOperation> {
         match &msg.message {
             Message::Cmd { .. } => writing::get_result(msg, &mut self.elder_stores).await,
-            Message::Query { .. } => reading::get_result(msg, &self.elder_stores).await.map(|c| c.into()),
+            Message::Query { .. } => reading::get_result(msg, &self.elder_stores)
+                .await
+                .map(|c| c.into()),
             _ => None, // only Queries and Cmds from client is handled at Metadata
         }
     }

--- a/src/node/elder_duties/data_section/metadata/reading.rs
+++ b/src/node/elder_duties/data_section/metadata/reading.rs
@@ -18,7 +18,7 @@ use sn_data_types::{
     SequenceRead,
 };
 
-pub(super) fn get_result(msg: MsgEnvelope, stores: &ElderStores) -> Option<MessagingDuty> {
+pub(super) async fn get_result(msg: MsgEnvelope, stores: &ElderStores) -> Option<MessagingDuty> {
     use DataQuery::*;
     let msg_id = msg.id();
     let origin = msg.origin;
@@ -29,9 +29,9 @@ pub(super) fn get_result(msg: MsgEnvelope, stores: &ElderStores) -> Option<Messa
             ..
         } => match &data_query {
             Blob(read) => blob(read, stores.blob_register(), msg_id, origin, proxies),
-            Map(read) => map(read, stores.map_storage(), msg_id, origin),
-            Sequence(read) => sequence(read, stores.sequence_storage(), msg_id, origin),
-            Account(read) => account(read, stores.account_storage(), msg_id, origin),
+            Map(read) => map(read, stores.map_storage(), msg_id, origin).await,
+            Sequence(read) => sequence(read, stores.sequence_storage(), msg_id, origin).await,
+            Account(read) => account(read, stores.account_storage(), msg_id, origin).await,
         },
         _ => unreachable!("Logic error"),
     }
@@ -47,29 +47,29 @@ fn blob(
     register.read(read, msg_id, origin, proxies) // since the data is sent on to adults, the entire msg is passed in
 }
 
-fn map(
+async fn map(
     read: &MapRead,
     storage: &MapStorage,
     msg_id: MessageId,
     origin: MsgSender,
 ) -> Option<MessagingDuty> {
-    storage.read(read, msg_id, &origin) // map data currently stay at elders, so the msg is not needed
+    storage.read(read, msg_id, &origin).await // map data currently stay at elders, so the msg is not needed
 }
 
-fn sequence(
+async fn sequence(
     read: &SequenceRead,
     storage: &SequenceStorage,
     msg_id: MessageId,
     origin: MsgSender,
 ) -> Option<MessagingDuty> {
-    storage.read(read, msg_id, &origin) // sequence data currently stay at elders, so the msg is not needed
+    storage.read(read, msg_id, &origin).await // sequence data currently stay at elders, so the msg is not needed
 }
 
-fn account(
+async fn account(
     read: &AccountRead,
     storage: &AccountStorage,
     msg_id: MessageId,
     origin: MsgSender,
 ) -> Option<MessagingDuty> {
-    storage.read(read, msg_id, &origin) // account data currently stay at elders, so the msg is not needed
+    storage.read(read, msg_id, &origin).await // account data currently stay at elders, so the msg is not needed
 }

--- a/src/node/elder_duties/data_section/metadata/writing.rs
+++ b/src/node/elder_duties/data_section/metadata/writing.rs
@@ -16,7 +16,7 @@ use sn_data_types::{
     MsgEnvelope, MsgSender, SequenceWrite,
 };
 
-pub(super) fn get_result(msg: MsgEnvelope, stores: &mut ElderStores) -> Option<NodeOperation> {
+pub(super) async fn get_result(msg: MsgEnvelope, stores: &mut ElderStores) -> Option<NodeOperation> {
     use DataCmd::*;
     let msg_id = msg.id();
     let msg_origin = msg.origin;
@@ -37,9 +37,9 @@ pub(super) fn get_result(msg: MsgEnvelope, stores: &mut ElderStores) -> Option<N
                 payment,
                 proxies,
             ),
-            Map(write) => map(write, stores.map_storage_mut(), msg_id, msg_origin),
-            Sequence(write) => sequence(write, stores.sequence_storage_mut(), msg_id, msg_origin),
-            Account(write) => account(write, stores.account_storage_mut(), msg_id, msg_origin),
+            Map(write) => map(write, stores.map_storage_mut(), msg_id, msg_origin).await,
+            Sequence(write) => sequence(write, stores.sequence_storage_mut(), msg_id, msg_origin).await,
+            Account(write) => account(write, stores.account_storage_mut(), msg_id, msg_origin).await,
         },
         _ => unreachable!("Logic error"),
     };
@@ -57,29 +57,29 @@ fn blob(
     register.write(write, msg_id, origin, payment, proxies)
 }
 
-fn map(
+async fn map(
     write: MapWrite,
     storage: &mut MapStorage,
     msg_id: MessageId,
     origin: MsgSender,
 ) -> Option<MessagingDuty> {
-    storage.write(write, msg_id, &origin)
+    storage.write(write, msg_id, &origin).await
 }
 
-fn sequence(
+async fn sequence(
     write: SequenceWrite,
     storage: &mut SequenceStorage,
     msg_id: MessageId,
     origin: MsgSender,
 ) -> Option<MessagingDuty> {
-    storage.write(write, msg_id, &origin)
+    storage.write(write, msg_id, &origin).await
 }
 
-fn account(
+async fn account(
     write: AccountWrite,
     storage: &mut AccountStorage,
     msg_id: MessageId,
     origin: MsgSender,
 ) -> Option<MessagingDuty> {
-    storage.write(write, msg_id, &origin)
+    storage.write(write, msg_id, &origin).await
 }

--- a/src/node/elder_duties/data_section/metadata/writing.rs
+++ b/src/node/elder_duties/data_section/metadata/writing.rs
@@ -16,7 +16,10 @@ use sn_data_types::{
     MsgEnvelope, MsgSender, SequenceWrite,
 };
 
-pub(super) async fn get_result(msg: MsgEnvelope, stores: &mut ElderStores) -> Option<NodeOperation> {
+pub(super) async fn get_result(
+    msg: MsgEnvelope,
+    stores: &mut ElderStores,
+) -> Option<NodeOperation> {
     use DataCmd::*;
     let msg_id = msg.id();
     let msg_origin = msg.origin;
@@ -38,8 +41,12 @@ pub(super) async fn get_result(msg: MsgEnvelope, stores: &mut ElderStores) -> Op
                 proxies,
             ),
             Map(write) => map(write, stores.map_storage_mut(), msg_id, msg_origin).await,
-            Sequence(write) => sequence(write, stores.sequence_storage_mut(), msg_id, msg_origin).await,
-            Account(write) => account(write, stores.account_storage_mut(), msg_id, msg_origin).await,
+            Sequence(write) => {
+                sequence(write, stores.sequence_storage_mut(), msg_id, msg_origin).await
+            }
+            Account(write) => {
+                account(write, stores.account_storage_mut(), msg_id, msg_origin).await
+            }
         },
         _ => unreachable!("Logic error"),
     };

--- a/src/node/elder_duties/data_section/mod.rs
+++ b/src/node/elder_duties/data_section/mod.rs
@@ -40,13 +40,13 @@ pub struct DataSection {
 
 impl DataSection {
     ///
-    pub fn new(
+    pub async fn new(
         info: &NodeInfo,
         total_used_space: &Rc<Cell<u64>>,
         routing: Network,
     ) -> Result<Self> {
         // Metadata
-        let metadata = Metadata::new(info, &total_used_space, routing.clone())?;
+        let metadata = Metadata::new(info, &total_used_space, routing.clone()).await?;
 
         // Rewards
         let keypair = utils::key_pair(routing.clone())?;
@@ -61,10 +61,10 @@ impl DataSection {
         })
     }
 
-    pub fn process(&mut self, duty: DataSectionDuty) -> Option<NodeOperation> {
+    pub async fn process(&mut self, duty: DataSectionDuty) -> Option<NodeOperation> {
         use DataSectionDuty::*;
         match duty {
-            RunAsMetadata(duty) => self.metadata.process(duty),
+            RunAsMetadata(duty) => self.metadata.process(duty).await,
             RunAsRewards(duty) => self.rewards.process(duty),
         }
     }

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -47,9 +47,9 @@ pub struct KeySection<R: CryptoRng + Rng> {
 }
 
 impl<R: CryptoRng + Rng> KeySection<R> {
-    pub fn new(info: &NodeInfo, routing: Network, rng: R) -> Result<Self> {
-        let mut gateway = ClientGateway::new(info, routing.clone(), rng)?;
-        let replica_manager = Self::new_replica_manager(info, routing.clone())?;
+    pub async fn new(info: &NodeInfo, routing: Network, rng: R) -> Result<Self> {
+        let gateway = ClientGateway::new(info, routing.clone(), rng)?;
+        let replica_manager = Self::new_replica_manager(info, routing.clone()).await?;
         let payments = Payments::new(info.keys.clone(), replica_manager.clone());
         let transfers = Transfers::new(info.keys.clone(), replica_manager.clone());
         let msg_analysis = ClientMsgAnalysis::new(routing.clone());
@@ -123,7 +123,7 @@ impl<R: CryptoRng + Rng> KeySection<R> {
         }
     }
 
-    fn new_replica_manager(
+    async fn new_replica_manager(
         info: &NodeInfo,
         routing: Network,
     ) -> Result<Rc<RefCell<ReplicaManager>>> {
@@ -131,7 +131,7 @@ impl<R: CryptoRng + Rng> KeySection<R> {
         let secret_key_share = routing.secret_key_share()?;
         let key_index = routing.our_index()?;
         let proof_chain = routing.our_history().ok_or(RoutingError::InvalidState)?;
-        let store = TransferStore::new(info.root_dir.clone(), info.init_mode)?;
+        let store = TransferStore::new(info.root_dir.clone(), info.init_mode).await?;
         let replica_manager = ReplicaManager::new(
             store,
             &secret_key_share,

--- a/src/node/elder_duties/key_section/transfers/store.rs
+++ b/src/node/elder_duties/key_section/transfers/store.rs
@@ -20,9 +20,9 @@ pub struct TransferStore {
 }
 
 impl TransferStore {
-    pub fn new<R: AsRef<Path>>(root_dir: R, init_mode: Init) -> Result<Self> {
+    pub async fn new<R: AsRef<Path>>(root_dir: R, init_mode: Init) -> Result<Self> {
         Ok(Self {
-            db: utils::new_db(root_dir, TRANSFERS_DB_NAME, init_mode)?,
+            db: utils::new_db(root_dir, TRANSFERS_DB_NAME, init_mode).await?,
         })
     }
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -52,15 +52,15 @@ impl<R: CryptoRng + Rng> Node<R> {
             None => {
                 let secret = SecretKey::random();
                 let public = secret.public_key();
-                store_new_reward_keypair(root_dir, &secret, &public)?;
+                store_new_reward_keypair(root_dir, &secret, &public).await?;
                 PublicKey::Bls(public)
             }
         };
-        let age_group = if let Some(age_group) = get_age_group(&root_dir)? {
+        let age_group = if let Some(age_group) = get_age_group(&root_dir).await? {
             age_group
         } else {
             let age_group = Infant;
-            store_age_group(root_dir, &age_group)?;
+            store_age_group(root_dir, &age_group).await?;
             age_group
         };
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -77,7 +77,7 @@ impl<R: CryptoRng + Rng> Node<R> {
             max_storage_capacity: config.max_capacity(),
         };
 
-        let mut duties = NodeDuties::new(node_info, network_api.clone(), rng);
+        let mut duties = NodeDuties::new(node_info, network_api.clone(), rng).await;
 
         use AgeGroup::*;
         let _ = match age_group {
@@ -162,11 +162,11 @@ impl<R: CryptoRng + Rng> Node<R> {
         match duty {
             RunAsAdult(duty) => {
                 info!("Running as Adult: {:?}", duty);
-                self.duties.adult_duties()?.process(&duty)
+                self.duties.adult_duties()?.process(&duty).await
             }
             RunAsElder(duty) => {
                 info!("Running as Elder: {:?}", duty);
-                self.duties.elder_duties()?.process(duty)
+                self.duties.elder_duties()?.process(duty).await
             }
             RunAsNode(duty) => {
                 info!("Running as Node: {:?}", duty);

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -147,7 +147,9 @@ impl<R: CryptoRng + Rng> NodeDuties<R> {
             &total_used_space,
             self.routing.clone(),
             self.rng.take()?,
-        ).await {
+        )
+        .await
+        {
             let mut duties = duties;
             let op = duties.initiate();
             self.duty_level = Elder(duties);

--- a/src/node/state_db.rs
+++ b/src/node/state_db.rs
@@ -10,41 +10,41 @@ use crate::{node::keys::NodeSigningKeys, utils, Error, Result};
 use bls::{self, serde_impl::SerdeSecret, PublicKey, SecretKey, PK_SIZE};
 use serde::{Deserialize, Serialize};
 use std::{
-    fs,
     path::{Path, PathBuf},
 };
+use tokio::fs;
 
 const AGE_GROUP_FILENAME: &str = "age_group";
 const REWARD_PUBLIC_KEY_FILENAME: &str = "reward_public_key";
 const REWARD_SECRET_KEY_FILENAME: &str = "reward_secret_key";
 
 /// Writes the public and secret key to different locations at disk.
-pub fn store_new_reward_keypair(
+pub async fn store_new_reward_keypair(
     root_dir: &Path,
     secret: &SecretKey,
     public: &PublicKey,
 ) -> Result<()> {
     let secret_key_path = root_dir.join(REWARD_SECRET_KEY_FILENAME);
     let public_key_path = root_dir.join(REWARD_PUBLIC_KEY_FILENAME);
-    fs::write(secret_key_path, sk_to_hex(secret))?;
-    fs::write(public_key_path, pk_to_hex(public))?;
+    fs::write(secret_key_path, sk_to_hex(secret)).await?;
+    fs::write(public_key_path, pk_to_hex(public)).await?;
     Ok(())
 }
 
 /// Writes the info to disk.
-pub fn store_age_group(root_dir: &Path, age_group: &AgeGroup) -> Result<()> {
+pub async fn store_age_group(root_dir: &Path, age_group: &AgeGroup) -> Result<()> {
     let path = root_dir.join(AGE_GROUP_FILENAME);
-    fs::write(path, utils::serialise(age_group))?;
+    fs::write(path, utils::serialise(age_group)).await?;
     Ok(())
 }
 
 /// Returns Some(AgeGroup) or None if file doesn't exist.
-pub fn get_age_group(root_dir: &Path) -> Result<Option<AgeGroup>> {
+pub async fn get_age_group(root_dir: &Path) -> Result<Option<AgeGroup>> {
     let path = root_dir.join(AGE_GROUP_FILENAME);
     if !path.is_file() {
         return Ok(None);
     }
-    let contents = fs::read(path)?;
+    let contents = fs::read(path).await?;
     Ok(Some(bincode::deserialize(&contents)?))
 }
 

--- a/src/node/state_db.rs
+++ b/src/node/state_db.rs
@@ -9,9 +9,7 @@
 use crate::{node::keys::NodeSigningKeys, utils, Error, Result};
 use bls::{self, serde_impl::SerdeSecret, PublicKey, SecretKey, PK_SIZE};
 use serde::{Deserialize, Serialize};
-use std::{
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 use tokio::fs;
 
 const AGE_GROUP_FILENAME: &str = "age_group";

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,10 +14,11 @@ use pickledb::{PickleDb, PickleDbDumpPolicy};
 use rand::{distributions::Standard, CryptoRng, Rng};
 use serde::{de::DeserializeOwned, Serialize};
 use sn_data_types::{BlsKeypairShare, Keypair};
-use std::{fs, path::Path};
+use std::path::Path;
+use tokio::fs;
 use unwrap::unwrap;
 
-pub(crate) fn new_db<D: AsRef<Path>, N: AsRef<Path>>(
+pub(crate) async fn new_db<D: AsRef<Path>, N: AsRef<Path>>(
     db_dir: D,
     db_name: N,
     init_mode: Init,
@@ -25,7 +26,7 @@ pub(crate) fn new_db<D: AsRef<Path>, N: AsRef<Path>>(
     let db_path = db_dir.as_ref().join(db_name);
     if init_mode == Init::New {
         trace!("Creating database at {}", db_path.display());
-        fs::create_dir_all(db_dir)?;
+        fs::create_dir_all(db_dir).await?;
         let mut db = PickleDb::new_bin(db_path, PickleDbDumpPolicy::AutoDump);
         // Write then delete a value to ensure DB file is actually written to disk.
         db.set("", &"")?;


### PR DESCRIPTION
fixes #1089 
fixes #1094 

Turns out the vault chunk storage subsystem on the whole doesn't use `async` yet, not just the `state_db` as I had thought when I opened #1089 and #1090 . Down the rabbit hole I went, and here's the result of converting all of the file accesses in chunk storage to `tokio::fs` from `std::fs`.

I think I got them all, but until qp2p and client libs are stable again, testing locally will have to wait. I'm leaving this as a draft for now.