### PR TITLE
chore(deps): update to reference renamed sn_routing

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -225,7 +225,7 @@ jobs:
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
 
-  # Not publishing to crates.io since the routing dependency points to a git repository.
+  # Not publishing to crates.io since the sn_routing dependency points to a git repository.
   # publish:
   #   name: Publish
   #   needs: deploy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ quick-error = "1.2.2"
 qp2p = { git = "https://github.com/maidsafe/qp2p", branch = "master", features = ["upnp"] }
 rand = "~0.7.3"
 rand_chacha = "~0.2.2"
-#routing = { path="../routing" }
+#sn_routing = { path="../sn_routing" }
 routing = { git = "https://github.com/joshuef/routing", branch = "update-quic" }
 self_update = { version = "~0.16.0", default-features = false, features = ["rustls", "archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate"] }
 serde = { version = "1.0.111", features = ["derive", "rc"] }

--- a/scripts/generate_dependency_graphs
+++ b/scripts/generate_dependency_graphs
@@ -7,5 +7,5 @@ mkdir images
 
 cargo install cargo-deps
 
-cargo deps --all-deps --include-orphans --filter safe_vault safe-nd routing quic-p2p lru_time_cache sn_fake_clock xor_name bls_dkg bls_signature_aggregator sn_transfers | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/safe_vault_maidsafe_dependencies.png
+cargo deps --all-deps --include-orphans --filter safe_vault sn_data_types sn_routing qp2p lru_time_cache sn_fake_clock xor_name bls_dkg bls_signature_aggregator sn_transfers | dot -T png -Nfontname=Iosevka -Gfontname=Iosevka -o images/safe_vault_maidsafe_dependencies.png
 cargo deps | dot -T png -o images/safe_vault_all_dependencies.png

--- a/src/bin/safe_vault.rs
+++ b/src/bin/safe_vault.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-//! SAFE Vault provides the interface to SAFE routing.  The resulting executable is the Vault node
+//! SAFE Vault provides the interface to sn_routing.  The resulting executable is the Vault node
 //! for the SAFE network.
 
 #![doc(

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -10,8 +10,8 @@ use crate::Result;
 use directories::ProjectDirs;
 use lazy_static::lazy_static;
 use log::{debug, Level};
-use routing::TransportConfig as NetworkConfig;
 use serde::{Deserialize, Serialize};
+use sn_routing::TransportConfig as NetworkConfig;
 use std::{
     fs::{self, File},
     io::{self, BufReader},

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,9 +60,9 @@ quick_error! {
             display("NetworkData Entry error: {:?}", error)
             from()
         }
-        /// Routing error.
-        Routing(error: routing::RoutingError) {
-            display("Routing error: {:?}", error)
+        /// SNRouting error.
+        SNRouting(error: sn_routing::SNRoutingError) {
+            display("sn_routing error: {:?}", error)
             from()
         }
         ///

--- a/src/node/adult_duties/chunks/mod.rs
+++ b/src/node/adult_duties/chunks/mod.rs
@@ -126,7 +126,7 @@ impl Chunks {
 
     // fn public_key(&self) -> Option<PublicKey> {
     //     Some(
-    //         self.routing_node
+    //         self.sn_routing_node
     //             .borrow()
     //             .public_key_set()
     //             .ok()?

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -51,7 +51,7 @@ pub(super) struct BlobRegister {
     holders: PickleDb,
     #[allow(unused)]
     full_adults: PickleDb,
-    routing: Network,
+    sn_routing: Network,
     wrapping: ElderMsgWrapping,
 }
 
@@ -59,7 +59,7 @@ impl BlobRegister {
     pub(super) fn new(
         node_info: &NodeInfo,
         wrapping: ElderMsgWrapping,
-        routing: Network,
+        sn_routing: Network,
     ) -> Result<Self> {
         let metadata = utils::new_db(node_info.path(), BLOB_META_DB_NAME, node_info.init_mode)?;
         let holders = utils::new_db(node_info.path(), HOLDER_META_DB_NAME, node_info.init_mode)?;
@@ -70,7 +70,7 @@ impl BlobRegister {
             metadata,
             holders,
             full_adults,
-            routing,
+            sn_routing,
             wrapping,
         })
     }
@@ -490,11 +490,13 @@ impl BlobRegister {
     // Used to fetch the list of holders for a new chunk.
     fn get_holders_for_chunk(&self, target: &XorName) -> Vec<XorName> {
         let take = CHUNK_ADULT_COPY_COUNT;
-        let mut closest_adults = self.routing.our_adults_sorted_by_distance_to(&target, take);
+        let mut closest_adults = self
+            .sn_routing
+            .our_adults_sorted_by_distance_to(&target, take);
         if closest_adults.len() < CHUNK_COPY_COUNT {
             let take = CHUNK_COPY_COUNT - closest_adults.len();
             let mut closest_elders = self
-                .routing
+                .sn_routing
                 .our_elder_names_sorted_by_distance_to(&target, take);
             closest_adults.append(&mut closest_elders);
             closest_adults

--- a/src/node/elder_duties/data_section/metadata/mod.rs
+++ b/src/node/elder_duties/data_section/metadata/mod.rs
@@ -49,11 +49,11 @@ impl Metadata {
     pub fn new(
         node_info: &NodeInfo,
         total_used_space: &Rc<Cell<u64>>,
-        routing: Network,
+        sn_routing: Network,
     ) -> Result<Self> {
         let wrapping = ElderMsgWrapping::new(node_info.keys(), ElderDuties::Metadata);
         let account_storage = AccountStorage::new(node_info, total_used_space, wrapping.clone())?;
-        let blob_register = BlobRegister::new(node_info, wrapping.clone(), routing)?;
+        let blob_register = BlobRegister::new(node_info, wrapping.clone(), sn_routing)?;
         let map_storage = MapStorage::new(node_info, total_used_space, wrapping.clone())?;
         let sequence_storage = SequenceStorage::new(node_info, total_used_space, wrapping.clone())?;
         let elder_stores = ElderStores::new(
@@ -189,7 +189,7 @@ impl Metadata {
     // ) -> Option<MessagingDuty> {
     //     use Response::*;
     //     if self
-    //         .routing
+    //         .sn_routing
     //         .borrow()
     //         .public_key_set()
     //         .ok()?
@@ -220,7 +220,7 @@ impl Metadata {
 
     // fn public_key(&self) -> Option<PublicKey> {
     //     Some(
-    //         self.routing
+    //         self.sn_routing
     //             .borrow()
     //             .public_key_set()
     //             .ok()?

--- a/src/node/elder_duties/key_section/client/onboarding.rs
+++ b/src/node/elder_duties/key_section/client/onboarding.rs
@@ -28,17 +28,17 @@ use std::{
 /// the Elders of this section.
 pub struct Onboarding {
     node_id: PublicKey,
-    routing: Network,
+    sn_routing: Network,
     clients: HashMap<SocketAddr, PublicKey>,
     // Map of new client connections to the challenge value we sent them.
     client_candidates: HashMap<SocketAddr, (Vec<u8>, PublicKey)>,
 }
 
 impl Onboarding {
-    pub fn new(node_id: PublicKey, routing: Network) -> Self {
+    pub fn new(node_id: PublicKey, sn_routing: Network) -> Self {
         Self {
             node_id,
-            routing,
+            sn_routing,
             clients: HashMap::<SocketAddr, PublicKey>::new(),
             client_candidates: Default::default(),
         }
@@ -102,11 +102,11 @@ impl Onboarding {
             "{}: Trying to bootstrap..: {} on {}",
             self, client_key, peer_addr
         );
-        let elders = if self.routing.matches_our_prefix((*client_key).into()) {
-            self.routing.our_elder_addresses()
+        let elders = if self.sn_routing.matches_our_prefix((*client_key).into()) {
+            self.sn_routing.our_elder_addresses()
         } else {
             let closest_known_elders = self
-                .routing
+                .sn_routing
                 .our_elder_addresses_sorted_by_distance_to(&(*client_key).into());
             if closest_known_elders.is_empty() {
                 trace!(
@@ -154,7 +154,7 @@ impl Onboarding {
             "{}: Trying to join..: {} on {}",
             self, client_key, peer_addr
         );
-        if self.routing.matches_our_prefix(client_key.into()) {
+        if self.sn_routing.matches_our_prefix(client_key.into()) {
             let challenge = if let Some((challenge, _)) = self.client_candidates.get(&peer_addr) {
                 challenge.clone()
             } else {

--- a/src/node/elder_duties/key_section/client_msg_analysis.rs
+++ b/src/node/elder_duties/key_section/client_msg_analysis.rs
@@ -14,12 +14,12 @@ use sn_data_types::{Cmd, Message, MsgEnvelope, MsgSender, Query};
 /// Evaluates msgs sent directly from a client,
 /// i.e. not remote msgs from the network.
 pub struct ClientMsgAnalysis {
-    routing: Network,
+    sn_routing: Network,
 }
 
 impl ClientMsgAnalysis {
-    pub fn new(routing: Network) -> Self {
-        Self { routing }
+    pub fn new(sn_routing: Network) -> Self {
+        Self { sn_routing }
     }
 
     pub fn evaluate(&mut self, msg: &MsgEnvelope) -> Option<NodeOperation> {
@@ -97,10 +97,11 @@ impl ClientMsgAnalysis {
     }
 
     fn is_dst_for(&self, msg: &MsgEnvelope) -> bool {
-        self.routing.matches_our_prefix(msg.destination().xorname())
+        self.sn_routing
+            .matches_our_prefix(msg.destination().xorname())
     }
 
     fn is_elder(&self) -> bool {
-        self.routing.is_elder()
+        self.sn_routing.is_elder()
     }
 }

--- a/src/node/elder_duties/key_section/transfers/replica_manager.rs
+++ b/src/node/elder_duties/key_section/transfers/replica_manager.rs
@@ -18,7 +18,7 @@ use sn_data_types::{
 use sn_transfers::{get_genesis, TransferReplica as Replica};
 use std::collections::BTreeSet;
 
-use routing::SectionProofChain;
+use sn_routing::SectionProofChain;
 #[cfg(feature = "simulated-payouts")]
 use {
     crate::node::node_ops::MessagingDuty,

--- a/src/node/elder_duties/mod.rs
+++ b/src/node/elder_duties/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use log::trace;
 use rand::{CryptoRng, Rng};
-use routing::Prefix;
+use sn_routing::Prefix;
 use std::{
     cell::Cell,
     fmt::{self, Display, Formatter},
@@ -36,12 +36,12 @@ impl<R: CryptoRng + Rng> ElderDuties<R> {
     pub fn new(
         info: &NodeInfo,
         total_used_space: &Rc<Cell<u64>>,
-        routing: Network,
+        sn_routing: Network,
         rng: R,
     ) -> Result<Self> {
-        let prefix = routing.our_prefix().ok_or(Error::Logic)?;
-        let key_section = KeySection::new(info, routing.clone(), rng)?;
-        let data_section = DataSection::new(info, total_used_space, routing)?;
+        let prefix = sn_routing.our_prefix().ok_or(Error::Logic)?;
+        let key_section = KeySection::new(info, sn_routing.clone(), rng)?;
+        let data_section = DataSection::new(info, total_used_space, sn_routing)?;
         Ok(Self {
             prefix,
             key_section,

--- a/src/node/keys.rs
+++ b/src/node/keys.rs
@@ -15,17 +15,21 @@ use sn_data_types::{
 
 #[derive(Clone)]
 pub struct NodeSigningKeys {
-    routing: Network,
+    sn_routing: Network,
 }
 
 impl NodeSigningKeys {
-    pub fn new(routing: Network) -> Self {
-        Self { routing }
+    pub fn new(sn_routing: Network) -> Self {
+        Self { sn_routing }
     }
 
     pub fn public_key(&self) -> Option<PublicKey> {
-        let index = self.routing.our_index().ok()?;
-        let share = self.routing.public_key_set().ok()?.public_key_share(index);
+        let index = self.sn_routing.our_index().ok()?;
+        let share = self
+            .sn_routing
+            .public_key_set()
+            .ok()?
+            .public_key_share(index);
         Some(PublicKey::BlsShare(share))
     }
 
@@ -67,7 +71,7 @@ impl NodeSigningKeys {
     }
 
     fn public_key_set(&self) -> Option<PublicKeySet> {
-        Some(self.routing.public_key_set().ok()?)
+        Some(self.sn_routing.public_key_set().ok()?)
     }
 
     /// Creates a detached Ed25519 signature of `data`.
@@ -78,8 +82,8 @@ impl NodeSigningKeys {
 
     /// Creates a detached BLS signature share of `data` if the `self` holds a BLS keypair share.
     fn sign_using_bls<T: AsRef<[u8]>>(&self, data: &T) -> Option<Signature> {
-        let index = self.routing.our_index().ok()?;
-        let bls_secret_key = self.routing.secret_key_share().ok()?;
+        let index = self.sn_routing.our_index().ok()?;
+        let bls_secret_key = self.sn_routing.secret_key_share().ok()?;
         Some(Signature::BlsShare(SignatureShare {
             index,
             share: bls_secret_key.sign(data),

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -28,8 +28,8 @@ use crate::{
 use bls::SecretKey;
 use log::info;
 use rand::{CryptoRng, Rng};
-use routing::event::Event;
 use sn_data_types::PublicKey;
+use sn_routing::event::Event;
 use std::{
     fmt::{self, Display, Formatter},
     net::SocketAddr,
@@ -109,7 +109,7 @@ impl<R: CryptoRng + Rng> Node<R> {
         self.network_api.our_connection_info().map_err(From::from)
     }
 
-    /// Returns whether routing node is in elder state.
+    /// Returns whether sn_routing node is in elder state.
     pub fn is_elder(&mut self) -> bool {
         self.network_api.is_elder()
     }
@@ -120,7 +120,7 @@ impl<R: CryptoRng + Rng> Node<R> {
     pub async fn run(&mut self) -> Result<()> {
         let mut event_stream = self.network_api.listen_events().await?;
         let info = self.network_api.our_connection_info().unwrap();
-        info!("Listening for routing events at: {}", info);
+        info!("Listening for sn_routing events at: {}", info);
         while let Some(event) = event_stream.next().await {
             info!("New event received from the Network: {:?}", event);
             let duty = if let Event::ClientMessageReceived { .. } = event {

--- a/src/node/node_duties/messaging/client_sender.rs
+++ b/src/node/node_duties/messaging/client_sender.rs
@@ -18,12 +18,12 @@ use std::{
 
 /// Sending of messages to clients.
 pub(super) struct ClientSender {
-    routing: Network,
+    sn_routing: Network,
 }
 
 impl ClientSender {
-    pub fn new(routing: Network) -> Self {
-        Self { routing }
+    pub fn new(sn_routing: Network) -> Self {
+        Self { sn_routing }
     }
 
     pub async fn send(
@@ -52,7 +52,11 @@ impl ClientSender {
         msg: &T,
     ) -> Option<MessagingDuty> {
         let bytes = utils::serialise(msg);
-        if let Err(e) = self.routing.send_message_to_client(recipient, bytes).await {
+        if let Err(e) = self
+            .sn_routing
+            .send_message_to_client(recipient, bytes)
+            .await
+        {
             warn!(
                 "{}: Could not send message to client {}: {:?}",
                 self, recipient, e

--- a/src/node/node_duties/messaging/mod.rs
+++ b/src/node/node_duties/messaging/mod.rs
@@ -23,9 +23,9 @@ pub struct Messaging {
 }
 
 impl Messaging {
-    pub fn new(routing: Network) -> Self {
-        let client_sender = ClientSender::new(routing.clone());
-        let network_sender = NetworkSender::new(routing);
+    pub fn new(sn_routing: Network) -> Self {
+        let client_sender = ClientSender::new(sn_routing.clone());
+        let network_sender = NetworkSender::new(sn_routing);
         Self {
             client_sender,
             network_sender,

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -43,22 +43,22 @@ pub struct NodeDuties<R: CryptoRng + Rng> {
     duty_level: DutyLevel<R>,
     network_events: NetworkEvents,
     messaging: Messaging,
-    routing: Network,
+    sn_routing: Network,
     rng: Option<R>,
 }
 
 impl<R: CryptoRng + Rng> NodeDuties<R> {
-    pub fn new(node_info: NodeInfo, routing: Network, rng: R) -> Self {
-        let network_events = NetworkEvents::new(NetworkMsgAnalysis::new(routing.clone()));
-        let is_genesis = &routing.is_genesis();
+    pub fn new(node_info: NodeInfo, sn_routing: Network, rng: R) -> Self {
+        let network_events = NetworkEvents::new(NetworkMsgAnalysis::new(sn_routing.clone()));
+        let is_genesis = &sn_routing.is_genesis();
 
-        let messaging = Messaging::new(routing.clone());
+        let messaging = Messaging::new(sn_routing.clone());
         let mut duties = Self {
             node_info,
             duty_level: DutyLevel::Infant,
             network_events,
             messaging,
-            routing,
+            sn_routing,
             rng: Some(rng),
         };
 
@@ -145,7 +145,7 @@ impl<R: CryptoRng + Rng> NodeDuties<R> {
         if let Ok(duties) = ElderDuties::new(
             &self.node_info,
             &total_used_space,
-            self.routing.clone(),
+            self.sn_routing.clone(),
             self.rng.take()?,
         ) {
             let mut duties = duties;

--- a/src/node/node_duties/msg_analysis.rs
+++ b/src/node/node_duties/msg_analysis.rs
@@ -26,14 +26,14 @@ use xor_name::XorName;
 /// i.e. not msgs sent directly from a client.
 pub struct NetworkMsgAnalysis {
     accumulation: Accumulation,
-    routing: Network,
+    sn_routing: Network,
 }
 
 impl NetworkMsgAnalysis {
-    pub fn new(routing: Network) -> Self {
+    pub fn new(sn_routing: Network) -> Self {
         Self {
             accumulation: Accumulation::new(),
-            routing,
+            sn_routing,
         }
     }
 
@@ -75,7 +75,7 @@ impl NetworkMsgAnalysis {
         use Address::*;
         let destined_for_network = || match msg.destination() {
             Client(address) => !self.self_is_handler_for(&address),
-            Node(address) => address != self.routing.our_name(),
+            Node(address) => address != self.sn_routing.our_name(),
             Section(address) => !self.self_is_handler_for(&address),
         };
 
@@ -404,7 +404,7 @@ impl NetworkMsgAnalysis {
                 } => {
                     // This comparison is a good example of the need to use `lazy messaging`,
                     // as to handle that the expected public key is not the same as the current.
-                    if public_key == &self.routing.public_key()? {
+                    if public_key == &self.sn_routing.public_key()? {
                         Some(TransferDuty::ProcessQuery {
                             query: TransferQuery::GetReplicaEvents,
                             msg_id: *id,
@@ -468,14 +468,14 @@ impl NetworkMsgAnalysis {
     }
 
     fn self_is_handler_for(&self, address: &XorName) -> bool {
-        self.routing.matches_our_prefix(*address)
+        self.sn_routing.matches_our_prefix(*address)
     }
 
     fn is_elder(&self) -> bool {
-        self.routing.is_elder()
+        self.sn_routing.is_elder()
     }
 
     fn is_adult(&self) -> bool {
-        self.routing.is_adult()
+        self.sn_routing.is_adult()
     }
 }

--- a/src/node/node_duties/network_events.rs
+++ b/src/node/node_duties/network_events.rs
@@ -11,8 +11,8 @@ use crate::node::node_ops::{ElderDuty, NodeDuty, NodeOperation};
 use bytes::Bytes;
 use hex_fmt::HexFmt;
 use log::{error, info, trace, warn};
-use routing::event::Event as RoutingEvent;
 use sn_data_types::{MsgEnvelope, PublicKey};
+use sn_routing::event::Event as SNRoutingEvent;
 use xor_name::XorName;
 
 /// Maps events from the transport layer
@@ -26,21 +26,21 @@ impl NetworkEvents {
         Self { analysis }
     }
 
-    pub fn process(&mut self, event: RoutingEvent) -> Option<NodeOperation> {
+    pub fn process(&mut self, event: SNRoutingEvent) -> Option<NodeOperation> {
         use ElderDuty::*;
         use NodeDuty::*;
 
-        trace!("Processing Routing Event: {:?}", event);
+        trace!("Processing sn_routing Event: {:?}", event);
         match event {
-            RoutingEvent::PromotedToAdult => {
+            SNRoutingEvent::PromotedToAdult => {
                 info!("Node promoted to Adult");
                 Some(BecomeAdult.into())
             }
-            RoutingEvent::PromotedToElder => {
+            SNRoutingEvent::PromotedToElder => {
                 info!("Node promoted to Elder");
                 Some(BecomeElder.into())
             }
-            RoutingEvent::MemberLeft { name, age } => {
+            SNRoutingEvent::MemberLeft { name, age } => {
                 trace!("A node has left the section. Node: {:?}", name);
                 Some(
                     ProcessLostMember {
@@ -50,11 +50,11 @@ impl NetworkEvents {
                     .into(),
                 )
             }
-            RoutingEvent::InfantJoined { name, .. } => {
+            SNRoutingEvent::InfantJoined { name, .. } => {
                 trace!("New node has joined the network");
                 Some(ProcessNewMember(XorName(name.0)).into())
             }
-            RoutingEvent::MemberJoined {
+            SNRoutingEvent::MemberJoined {
                 name,
                 previous_name,
                 age,
@@ -69,11 +69,11 @@ impl NetworkEvents {
                     .into(),
                 )
             }
-            RoutingEvent::Connected(_) => {
+            SNRoutingEvent::Connected(_) => {
                 info!("Node connected.");
                 None
             }
-            RoutingEvent::MessageReceived { content, src, dst } => {
+            SNRoutingEvent::MessageReceived { content, src, dst } => {
                 info!(
                     "Received network message: {:8?}\n Sent from {:?} to {:?}",
                     HexFmt(&content),
@@ -82,7 +82,7 @@ impl NetworkEvents {
                 );
                 self.evaluate_msg(content)
             }
-            RoutingEvent::EldersChanged {
+            SNRoutingEvent::EldersChanged {
                 key,
                 elders,
                 prefix,

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -10,12 +10,12 @@
 use sn_data_types::Transfer;
 
 use qp2p::SendStream;
-use routing::{event::Event as RoutingEvent, Prefix};
 use serde::export::Formatter;
 use sn_data_types::{
     AccountId, Address, DebitAgreementProof, HandshakeResponse, MessageId, MsgEnvelope, PublicKey,
     ReplicaEvent, SignedTransfer, TransferValidated,
 };
+use sn_routing::{event::Event as SNRoutingEvent, Prefix};
 use std::fmt::Debug;
 use std::{collections::BTreeSet, net::SocketAddr};
 use xor_name::XorName;
@@ -105,7 +105,7 @@ pub enum NodeDuty {
     /// Sending messages on to the network.
     ProcessMessaging(MessagingDuty),
     /// Receiving and processing events from the network.
-    ProcessNetworkEvent(RoutingEvent),
+    ProcessNetworkEvent(SNRoutingEvent),
 }
 
 impl Into<NodeOperation> for NodeDuty {
@@ -316,7 +316,7 @@ pub enum GatewayDuty {
     FindClientFor(MsgEnvelope),
     /// Incoming events from clients are parsed
     /// at the Gateway, and forwarded to other modules.
-    ProcessClientEvent(RoutingEvent),
+    ProcessClientEvent(SNRoutingEvent),
 }
 
 impl Into<NodeOperation> for GatewayDuty {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,7 +13,7 @@ use crate::{Command, Config, Node};
 use crossbeam_channel::Sender;
 use file_per_thread_logger::{self as logger, FormatFn};
 use qp2p::Config as NetworkConfig;
-use routing::NodeConfig as RoutingConfig;
+use sn_routing::NodeConfig as SNRoutingConfig;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::thread::{self, JoinHandle};
@@ -63,9 +63,9 @@ impl Network {
                 genesis_config.set_root_dir(&path);
                 genesis_config.listen_on_loopback();
 
-                let mut routing_config = RoutingConfig::default();
-                routing_config.first = genesis_config.is_first();
-                routing_config.transport_config = genesis_config.network_config().clone();
+                let mut sn_routing_config = SNRoutingConfig::default();
+                sn_routing_config.first = genesis_config.is_first();
+                sn_routing_config.transport_config = genesis_config.network_config().clone();
 
                 let mut node =
                     futures::executor::block_on(Node::new(&genesis_config, rand::thread_rng()))
@@ -96,8 +96,8 @@ impl Network {
                     vault_config.set_network_config(network_config);
                     vault_config.listen_on_loopback();
 
-                    let mut routing_config = RoutingConfig::default();
-                    routing_config.transport_config = vault_config.network_config().clone();
+                    let mut sn_routing_config = SNRoutingConfig::default();
+                    sn_routing_config.transport_config = vault_config.network_config().clone();
 
                     let mut node =
                         futures::executor::block_on(Node::new(&vault_config, rand::thread_rng()))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,12 +54,12 @@ pub(crate) fn deserialise<T: DeserializeOwned>(bytes: &[u8]) -> T {
 }
 
 // NB: needs to allow for nodes not having a key share yet?
-pub(crate) fn key_pair(routing: Network) -> Result<Keypair> {
-    let index = routing.our_index()?;
-    let bls_secret_key = routing.secret_key_share()?;
+pub(crate) fn key_pair(sn_routing: Network) -> Result<Keypair> {
+    let index = sn_routing.our_index()?;
+    let bls_secret_key = sn_routing.secret_key_share()?;
     let secret = SerdeSecret(bls_secret_key.clone());
     let public = bls_secret_key.public_key_share();
-    let public_key_set = routing.public_key_set()?;
+    let public_key_set = sn_routing.public_key_set()?;
     Ok(Keypair::BlsShare(BlsKeypairShare {
         index,
         secret,


### PR DESCRIPTION
Includes cargo fmt suggestions.

safe-vault master currently points to a `routing` fork as a dep so I have left that in place & updated all other references to `sn_routing`.

Note that safe-vault CI is currently failing due to an issue unrelated to this PR so will come back with 4 clippy failures.