### PR TITLE
Minor fixes to payment/rewards docs and logics.

### DIFF
--- a/src/node/elder_duties/data_section/rewards/mod.rs
+++ b/src/node/elder_duties/data_section/rewards/mod.rs
@@ -236,7 +236,7 @@ impl Rewards {
         node_id: XorName,
     ) -> Option<NodeMessagingDuty> {
         // If we ever hit these errors, something is very odd
-        // most likely a bug, because we are receiving an event triggered by our cmd.
+        // most likely a bug, because we are receiving a response to our query.
         // So, it doesn't make much sense to send some error msg back on the wire.
         // Makes more sense to panic, or log and just drop the request.
         // But exact course to take there needs to be chiseled out.

--- a/src/node/elder_duties/key_section/payment/mod.rs
+++ b/src/node/elder_duties/key_section/payment/mod.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 /// requests from clients.
 /// At Payments, a local request to Transfers module
 /// will clear the payment, and thereafter the node forwards
-/// the actual write request (without payment info) to a DataSection,
+/// the actual write request to a DataSection,
 /// which would be a section closest to the data
 /// (where it is then handled by Elders with Metadata duties).
 pub struct Payments {
@@ -98,9 +98,6 @@ impl Payments {
         let result = match result {
             Ok(_) => {
                 // Paying too little will see the amount be forfeited.
-                // This is because it is easy to know the cost by
-                // serializing the write and counting the num bytes,
-                // so you are forced to do the job properly.
                 // This prevents spam of the network.
                 let total_cost = self.rate_limit.from(num_bytes).await?;
                 if total_cost > payment.amount() {


### PR DESCRIPTION
fix(section_funds): improve logic
- Don't pop a queue before a potentially failing call.
- Don't leave room for other sender than current actor, when
determining if transition credit.

fix(docs): update docs to reflect recent changes